### PR TITLE
Improve documentation

### DIFF
--- a/rash_book/src/contributing.md
+++ b/rash_book/src/contributing.md
@@ -1,4 +1,4 @@
-## How to Contribute
+# How to Contribute
 
 The Rash project in under [The GNU General Public License v3.0](LICENSE). We accept contributions
 via GitHub pull requests. This document outlines some of the conventions related to
@@ -15,7 +15,7 @@ contribution. See the [DCO](DCO) file for details.
 Contributors sign-off that they adhere to these requirements by adding a
 Signed-off-by line to commit messages. For example:
 
-```
+```text
 This is my commit message
 
 Signed-off-by: Random J Developer <random@developer.example.org>
@@ -24,14 +24,14 @@ Signed-off-by: Random J Developer <random@developer.example.org>
 Git even has a -s command line option to append this automatically to your
 commit message:
 
-```
-$ git commit -s -m 'This is my commit message'
+```shell
+git commit -s -m 'This is my commit message'
 ```
 
 If you have already made a commit and forgot to include the sign-off, you can amend your last commit
 to add the sign-off with the following command, which can then be force pushed.
 
-```
+```shell
 git commit --amend -s
 ```
 
@@ -71,7 +71,7 @@ understand (A) what this piece of code's responsibility is within Rash's archite
 was written as it was.
 
 The below blog entry explains more the why's and how's of this guideline.
-https://blog.codinghorror.com/code-tells-you-how-comments-tell-you-why/
+<https://blog.codinghorror.com/code-tells-you-how-comments-tell-you-why/>
 
 ## Commit Messages
 
@@ -79,7 +79,7 @@ We follow a rough convention for commit messages that is designed to answer two
 questions: what changed and why. The subject line should feature the what and
 the body of the commit should describe the why.
 
-```
+```text
 ceph: update MON to use rocksdb
 
 this enables us to remove leveldb from the codebase.
@@ -87,7 +87,7 @@ this enables us to remove leveldb from the codebase.
 
 The format can be described more formally as follows:
 
-```
+```text
 <area>: <what changed>
 <BLANK LINE>
 <why this change was made>

--- a/rash_book/src/install.md
+++ b/rash_book/src/install.md
@@ -5,7 +5,8 @@
 
 ## Build requirements
 
-The following tools are need:
+The following tools are needed:
+
 - docker
 - make
 - rustc

--- a/rash_book/src/roadmap.md
+++ b/rash_book/src/roadmap.md
@@ -1,6 +1,6 @@
 # Roadmap <!-- omit in toc -->
 
-The projects Roadmap is defined in our
+The project Roadmap is defined in our
 [Concept Map](https://mind42.com/mindmap/f299679e-8dc5-48d8-b0f0-4d65235cdf56). Some more
 concrete examples can be found below.
 
@@ -22,6 +22,7 @@ These are just some ideas about the possibilities of `rash`.
 ### S3
 
 `s3.rh`:
+
 ```yaml
 #!/bin/rash
 
@@ -39,6 +40,7 @@ These are just some ideas about the possibilities of `rash`.
 ### vault
 
 `vault.rh`:
+
 ```yaml
 #!/bin/rash
 
@@ -52,6 +54,7 @@ These are just some ideas about the possibilities of `rash`.
 ### etcd
 
 `etcd.rh`:
+
 ```yaml
 #!/bin/rash
 
@@ -78,6 +81,7 @@ These are just some ideas about the possibilities of `rash`.
 ### S3
 
 `s3.rh`:
+
 ```yaml
 #!/bin/rash
 

--- a/rash_book/src/tasks.md
+++ b/rash_book/src/tasks.md
@@ -16,7 +16,8 @@ Tasks admit the following keys:
 
 ### Register structure
 
-Register saves in a variable a modules result structure like this one:
+Use the Register field to define the name of the variable in which you wish to save
+the module result. Its value will conform to the following structure:
 
 ```rust,no_run,noplaypen
 {{#include ../../rash_core/src/modules/mod.rs:module_result}}

--- a/rash_book/src/tasks.md
+++ b/rash_book/src/tasks.md
@@ -1,6 +1,6 @@
 # Tasks
 
-`tasks` are main execution unit. They need a module and admits some optional fields described below.
+`tasks` are the main execution unit. They need a module and admit some optional fields described below.
 
 ```yaml
 {{#include ../../examples/copy.rh:3:}}
@@ -8,7 +8,7 @@
 
 ## Fields
 
-Tasks admits the following keys:
+Tasks admit the following keys:
 
 ```rust,no_run,noplaypen
 {{#include ../../rash_core/src/task/mod.rs:task}}
@@ -23,7 +23,7 @@ Register saves in a variable a modules result structure like this one:
 ```
 
 For example:
+
 ```yaml
 {{#include ../../examples/register.rh:3:}}
 ```
-

--- a/rash_book/src/title-page.md
+++ b/rash_book/src/title-page.md
@@ -1,20 +1,23 @@
 # Rash Book
 
-`rash` solves an optimization problem in containers ecosystem. Nowadays, container *entrypoints*
-must be written in `bash` or included in the binary (the program itself). This is a trade off
-decision between being fast or being reusable, efficient, flexible...
+`rash` solves an optimization problem in the containers ecosystem.
 
-Beside, *entrypoints* share use cases between kind of applications (for example
-[databases entrypoints](https://github.com/pando85/entrypoint-examples) are quite similar).
-Or between platforms you have to provision your containers with same tools to care about
-secrets, configuration management...
+Nowadays, container *entrypoints* must be written in `bash` or included in the binary
+(the program itself). This is a trade-off decision between being fast or being reusable,
+efficient, flexible...
+
+Besides, *entrypoints* share use cases between different kinds of applications, e.g.
+[databases entrypoints](https://github.com/pando85/entrypoint-examples) are quite similar.
+Likewise, you might need to provision your containers between different platforms with the same
+tools, paying attention to secrets, configuration management...
 
 `rash` provides:
-- **simple syntax** to maintain low complexity.
-- static binary to be **container oriented**.
-- **declarative** syntax to be idempotent.
-- **clear output** to log properly.
-- **secure** by design.
-- **fast and efficient** (TODO: performance tests versus `bash`).
-- **modular** design.
-- support [Tera](https://tera.netlify.app/) **templates**.
+
+- A **simple syntax** to maintain low complexity.
+- One static binary to be **container oriented**.
+- A **declarative** syntax to be idempotent.
+- **Clear output** to log properly.
+- **Security** by design.
+- **Speed and efficiency** (TODO: performance tests versus `bash`).
+- **Modular** design.
+- Support of [Tera](https://tera.netlify.app/) **templates**.

--- a/rash_book/src/vars.md
+++ b/rash_book/src/vars.md
@@ -1,38 +1,40 @@
 # Vars <!-- omit in toc -->
 
-`rash` Context has variables associated to use as [Tera](https://tera.netlify.app/) templates.
-You can use them everywhere except in Yaml keys and they are going to be rendered at execution time.
+The `rash` context has variables associated to use as [Tera](https://tera.netlify.app/) templates.
+You can use them everywhere except in Yaml keys. They will be rendered at execution time.
 
 There are two kind of variables:
+
 - [Core](#core)
 - [Runtime](#runtime)
 
 ## Core
 
-By default, every execution of rash expose `{{ rash }}` and `{{ env }}` variables to Context.
+By default, every execution of rash exposes two variables to the Context: `{{ rash }}` and `{{ env }}`.
 
 ### rash <!-- omit in toc -->
 
-`{{ rash }}` variables are builtin values gotten from execution context.
+`{{ rash }}` variables are builtin values retrieved from execution context.
 
 {{#include_doc {{#include ../../rash_core/src/vars/builtin.rs:examples}}}}
 
 `src/vars/builtin.rs`:
+
 ```rust,no_run,noplaypen
 {{#include ../../rash_core/src/vars/builtin.rs:builtins}}
 ```
 
-
 ### env <!-- omit in toc -->
 
-Any environment var could be accessed as `{{ env.MY_ENV_VAR }}`.
+Any environment var can be accessed as `{{ env.MY_ENV_VAR }}`.
 
-Also, you can use command line to pass environment variables:
+Also, you can use command line arguments to pass environment variables:
+
 ```bash
 rash -e MY_ENV_VAR=foo example.rh
 ```
 
 ## Runtime
 
-In runtime, Variables could be added. You can check [module: set_vars](./set_vars.html) or
-[Tasks](./tasks.html) fields to get more information.
+It's possible to set Variables in runtime, too. Check sections [module: set_vars](./set_vars.html) or
+[Tasks](./tasks.html) to get additional information.

--- a/rash_core/src/modules/mod.rs
+++ b/rash_core/src/modules/mod.rs
@@ -13,17 +13,17 @@ use serde::Serialize;
 use serde_json::Value;
 use yaml_rust::Yaml;
 
-/// Return values by [`Module`] execution.
+/// Return values of a [`Module`] execution.
 ///
 /// [`Module`]: struct.Module.html
 #[derive(Clone, Debug, PartialEq, Serialize)]
 // ANCHOR: module_result
 pub struct ModuleResult {
-    /// True when module changed something.
+    /// True when the executed module changed something.
     changed: bool,
-    /// Output value is showed in logs when module is executed.
+    /// Output value will appear in logs when module is executed.
     output: Option<String>,
-    /// Extra field is used by modules to return its own data.
+    /// Extra field is used by modules to return their own data.
     extra: Option<Value>,
 }
 // ANCHOR_END: module_result


### PR DESCRIPTION
I noticed a few grammar issues and typos in the documentation. It's nothing serious, but I thought it was a good idea to fix those before the documentation grows.

I also fixed some issues pointed out by markdownlint. There's no markdownlint saved in this repo, so those changes might not fit the intended Markdown policy. Feel free to change those if you're not comfortable with them.