### PR TITLE
cli: fix multiple args passed

### DIFF
--- a/rash_core/src/main.rs
+++ b/rash_core/src/main.rs
@@ -44,8 +44,8 @@ struct Opts {
     #[clap(short, long, parse(try_from_str = parse_key_val), number_of_values = 1)]
     environment: Vec<(String, String)>,
     /// Additional args to be accessible from builtin `{{ rash.args }}` as list of strings
-    #[clap(multiple = true, takes_value = true)]
-    _args: Option<String>,
+    #[clap(multiple = true, takes_value = true, number_of_values = 1)]
+    _args: Vec<String>,
 }
 
 /// Fail program printing [`Error`] and returning code associated if exists.
@@ -84,10 +84,7 @@ fn main() {
             vars.insert(
                 "rash",
                 &Builtins::new(
-                    opts._args
-                        .unwrap_or_else(|| "".to_string())
-                        .split(' ')
-                        .collect::<Vec<&str>>(),
+                    opts._args.iter().map(|s| &**s).collect::<Vec<&str>>(),
                     script_path,
                 )
                 .unwrap(),

--- a/rash_core/src/vars/builtin.rs
+++ b/rash_core/src/vars/builtin.rs
@@ -61,3 +61,16 @@ impl Builtins {
         })
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_builtin_new() {
+        let builtins = Builtins::new(vec![], Path::new("/example.rh")).unwrap();
+        assert_eq!(builtins.args.len(), 0);
+        assert_eq!(builtins.path.as_os_str(), "/example.rh");
+        assert_eq!(builtins.dir.as_os_str(), "/");
+    }
+}


### PR DESCRIPTION
`{{ rash.args }}` was returning just the first argument.
Add some basic test to builtins.