### PR TITLE
Run commitlint on each commit

### DIFF
--- a/.cargo-husky/hooks/commit-msg
+++ b/.cargo-husky/hooks/commit-msg
@@ -1,0 +1,11 @@
+set -e
+
+if ! command -v docker > /dev/null; then
+  echo "Please install docker to run commit lint." >&2
+  exit 1
+fi
+
+root_dir=$(git rev-parse --show-toplevel)
+
+echo "Running commit lint on $1..."
+docker run --volume "${root_dir}:/app" --rm gtramontina/commitlint:8.3.5 -e "$1"

--- a/.cargo-husky/hooks/commit-msg
+++ b/.cargo-husky/hooks/commit-msg
@@ -8,4 +8,6 @@ fi
 root_dir=$(git rev-parse --show-toplevel)
 
 echo "Running commit lint on $1..."
+echo "You can find detailed information about commit message format here:"
+echo "  https://github.com/rash-sh/rash/blob/master/rash_book/src/contributing.md#commit-messages"
 docker run --volume "${root_dir}:/app" --rm gtramontina/commitlint:8.3.5 -e "$1"

--- a/.cargo-husky/hooks/pre-commit
+++ b/.cargo-husky/hooks/pre-commit
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+set -e
+
+#echo '+cargo clippy -- -D warnings'
+#cargo clippy -- -D warnings
+#echo '+cargo fmt -- --check'
+#cargo fmt -- --check

--- a/.cargo-husky/hooks/pre-commit
+++ b/.cargo-husky/hooks/pre-commit
@@ -2,7 +2,7 @@
 
 set -e
 
-#echo '+cargo clippy -- -D warnings'
-#cargo clippy -- -D warnings
-#echo '+cargo fmt -- --check'
-#cargo fmt -- --check
+echo '+cargo clippy -- -D warnings'
+cargo clippy -- -D warnings
+echo '+cargo fmt -- --check'
+cargo fmt -- --check

--- a/rash_book/src/contributing.md
+++ b/rash_book/src/contributing.md
@@ -105,3 +105,16 @@ The first line is the subject and should be no longer than 70 characters, the
 second line is always blank, and other lines should be wrapped at 80 characters.
 This allows the message to be easier to read on GitHub as well as in various
 git tools.
+
+**Important!** Any submitted pull request needs to have commit messages validated according
+to that specification. To avoid nasty surprises, we set up a `commit-msg` hook that validates
+your commit message before the commit actually takes place.
+
+You need to install [Docker](https://docs.docker.com/engine/install/) for this hook to work.
+If you're working on Linux, make sure you can run it with non-root permissions! More info
+[here](https://docs.docker.com/engine/install/linux-postinstall/).
+
+Finally, keep in mind that you need to set up the hooks before you commit for the first time.
+It's really easy, as `cargo-husky` takes care of the whole thing. You just need to ensure you
+run `cargo test` at least once before committing. If the hooks changed at some point in the repo,
+remove any `target` directory and run `cargo test` again.

--- a/rash_core/Cargo.toml
+++ b/rash_core/Cargo.toml
@@ -38,4 +38,4 @@ tempfile = "3"
 [dev-dependencies.cargo-husky]
 version = "1"
 default-features = false # Disable features which are enabled by default
-features = ["precommit-hook", "run-cargo-fmt", "run-cargo-clippy"]
+features = ["user-hooks"]


### PR DESCRIPTION
Commit linting is a really powerful technique to ensure commit messages conform to a given format.

However, if users can't have feedback about their commit messages *before* the commits take place, we risk PRs to be rejected by incorrect commit message format. And that situation doesn't have an easy way out.

We'd like our contributors to be happy and feel like they're working in a
friendly environment. That's why I feel that the best approach is to process
every commit message and notify the committer immediately if the commit message
isn't valid. Commits with invalid messages will be rejected, so there aren't
any issues coming up after the fact.

Resolves #88