### PR TITLE
doc: html to jekyll

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -33,9 +33,6 @@ jobs:
           # Strip git ref prefix from version
           VERSION=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')
 
-          # Strip "v" prefix from tag name
-          [[ "${{ github.ref }}" == "refs/tags/"* ]] && VERSION=$(echo $VERSION | sed -e 's/^v//')
-
           VERSION=$VERSION make book
 
       - name: Deploy

--- a/Makefile
+++ b/Makefile
@@ -64,8 +64,7 @@ mdbook-rash:	## install mdbook_rash to create rash_book
 
 book:	## create rash_book under rash_book/rash-sh.github.io
 book:	mdbook-rash
-	cd rash_book && \
-	MDBOOK_BUILD__BUILD_DIR=rash-sh.github.io/docs/rash/$(VERSION) mdbook build
+	MDBOOK_BUILD__BUILD_DIR=rash-sh.github.io/docs/rash/$(VERSION) mdbook build rash_book
 
 release:	## generate vendor.tar.gz and rash-v${VERSION}-x86_64-unkown-linux-gnu.tar.gz
 	cargo vendor

--- a/rash_book/book.toml
+++ b/rash_book/book.toml
@@ -9,3 +9,5 @@ title = "Rash book"
 build-dir = "rash-sh.github.io/docs/rash/master"
 
 [preprocessor.rash]
+
+[output.markdown]

--- a/rash_book/src/SUMMARY.md
+++ b/rash_book/src/SUMMARY.md
@@ -1,6 +1,6 @@
 # Rash Book
 
-[Rash Book](title-page.md)
+[Rash Book](index.md)
 
 - [Getting Started](getting-started.md)
 - [Tasks](tasks.md)

--- a/rash_book/src/builtins.md
+++ b/rash_book/src/builtins.md
@@ -1,3 +1,9 @@
+---
+title: Bultins
+weight: 5100
+indent: true
+---
+
 # Bultins
 
 By default, every execution of `rash` exposes two variables to the Context: `{{ rash }}` and

--- a/rash_book/src/contributing.md
+++ b/rash_book/src/contributing.md
@@ -1,3 +1,8 @@
+---
+title: Contributing
+weight: 7000
+---
+
 # Contributing
 
 Anyone can contribute whether you're new to the project or you've been around a long time.

--- a/rash_book/src/filters.md
+++ b/rash_book/src/filters.md
@@ -1,3 +1,9 @@
+---
+title: Filters
+weight: 5220
+indent: true
+---
+
 # Filters
 
 incoming...

--- a/rash_book/src/getting-started.md
+++ b/rash_book/src/getting-started.md
@@ -1,3 +1,8 @@
+---
+title: Getting started
+weight: 2000
+---
+
 # Getting started
 
 Simple YAML declarative shell scripting language based on modules and templates.

--- a/rash_book/src/index.md
+++ b/rash_book/src/index.md
@@ -1,3 +1,8 @@
+---
+title: Rash Book
+weight: 000
+---
+
 # Rash Book
 
 `rash` solves an optimization problem in the containers ecosystem.

--- a/rash_book/src/lookups.md
+++ b/rash_book/src/lookups.md
@@ -1,3 +1,9 @@
+---
+title: Lookups
+weight: 5210
+indent: true
+---
+
 # Lookups
 
 incoming...

--- a/rash_book/src/module_index.md
+++ b/rash_book/src/module_index.md
@@ -1,3 +1,8 @@
+---
+title: Module Index
+weight: 4000
+---
+
 # Module Index
 
 {{#include_module {{#include ../../rash_core/src/modules/assert.rs:module}}}}

--- a/rash_book/src/roadmap.md
+++ b/rash_book/src/roadmap.md
@@ -1,3 +1,8 @@
+---
+title: Roadmap
+weight: 6000
+---
+
 # Roadmap <!-- omit in toc -->
 
 The project Roadmap is defined in our

--- a/rash_book/src/runtime.md
+++ b/rash_book/src/runtime.md
@@ -1,3 +1,9 @@
+---
+title: Runtime
+weight: 5200
+indent: true
+---
+
 # Runtime
 
 It's possible to set Variables in runtime, too. Check sections [module: set_vars](./set_vars.html)

--- a/rash_book/src/tasks.md
+++ b/rash_book/src/tasks.md
@@ -1,3 +1,8 @@
+---
+title: Tasks
+weight: 3000
+---
+
 # Tasks
 
 `tasks` are the main execution unit. They need a module and admit some optional fields described below.

--- a/rash_book/src/vars.md
+++ b/rash_book/src/vars.md
@@ -1,3 +1,8 @@
+---
+title: Vars
+weight: 5000
+---
+
 # Vars <!-- omit in toc -->
 
 The `rash` context has variables associated to use as [Tera](https://tera.netlify.app/) templates.


### PR DESCRIPTION
Change all mdbook to produce a markdown output with Jekyll syntax.
This integrates better with rash-sh.github.io and allow better nav
in the website.