### PR TITLE
core: update rust to 1.46

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE=ekidd/rust-musl-builder:1.44.0
+ARG BASE_IMAGE=ekidd/rust-musl-builder:1.46.0
 FROM ${BASE_IMAGE} AS builder
 LABEL mantainer pando855@gmail.com
 

--- a/Dockerfile.debian
+++ b/Dockerfile.debian
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE=rust:1.44
+ARG BASE_IMAGE=rust:1.46
 FROM ${BASE_IMAGE} AS builder
 LABEL mantainer pando855@gmail.com
 

--- a/rash_core/src/logger.rs
+++ b/rash_core/src/logger.rs
@@ -74,7 +74,7 @@ pub fn setup_logging(verbosity: u8) -> Result<()> {
     base_config
         .chain(stdout_config)
         .apply()
-        .or_else(|e| Err(Error::new(ErrorKind::InvalidData, e)))?;
+        .map_err(|e| Error::new(ErrorKind::InvalidData, e))?;
 
     Ok(())
 }

--- a/rash_core/src/modules/command.rs
+++ b/rash_core/src/modules/command.rs
@@ -102,7 +102,7 @@ pub fn exec(optional_params: Yaml, vars: Vars) -> Result<(ModuleResult, Vars)> {
             // safe unwrap: verify in parse_params
             .args(vec!["-c", &params.cmd.unwrap()])
             .output()
-            .or_else(|e| Err(Error::new(ErrorKind::SubprocessFail, e)))?
+            .map_err(|e| Error::new(ErrorKind::SubprocessFail, e))?
     } else {
         // safe unwrap: verify in parse_params
         let argv = params.argv.unwrap();
@@ -114,18 +114,18 @@ pub fn exec(optional_params: Yaml, vars: Vars) -> Result<(ModuleResult, Vars)> {
         Command::new(program)
             .args(args)
             .output()
-            .or_else(|e| Err(Error::new(ErrorKind::SubprocessFail, e)))?
+            .map_err(|e| Error::new(ErrorKind::SubprocessFail, e))?
     };
 
     trace!("exec - output: {:?}", output);
     let stderr =
-        String::from_utf8(output.stderr).or_else(|e| Err(Error::new(ErrorKind::InvalidData, e)))?;
+        String::from_utf8(output.stderr).map_err(|e| Error::new(ErrorKind::InvalidData, e))?;
 
     if !output.status.success() {
         return Err(Error::new(ErrorKind::InvalidData, stderr));
     }
     let output_string =
-        String::from_utf8(output.stdout).or_else(|e| Err(Error::new(ErrorKind::InvalidData, e)))?;
+        String::from_utf8(output.stdout).map_err(|e| Error::new(ErrorKind::InvalidData, e))?;
 
     let module_output = if output_string.is_empty() {
         None

--- a/rash_core/src/modules/set_vars.rs
+++ b/rash_core/src/modules/set_vars.rs
@@ -42,16 +42,16 @@ pub fn exec(params: Yaml, vars: Vars) -> Result<(ModuleResult, Vars)> {
                 format!("{:?} must be a dict", &params),
             )
         })
-        .or_else(|e| Err(Error::new(ErrorKind::InvalidData, e)))?
+        .map_err(|e| Error::new(ErrorKind::InvalidData, e))?
         .iter()
         .map(|hash_map| {
             let mut yaml_str = String::new();
             let mut emitter = YamlEmitter::new(&mut yaml_str);
             emitter
                 .dump(hash_map.1)
-                .or_else(|e| Err(Error::new(ErrorKind::InvalidData, e)))?;
+                .map_err(|e| Error::new(ErrorKind::InvalidData, e))?;
             let yaml: Value = serde_yaml::from_str(&yaml_str)
-                .or_else(|e| Err(Error::new(ErrorKind::InvalidData, e)))?;
+                .map_err(|e| Error::new(ErrorKind::InvalidData, e))?;
 
             new_vars.insert(
                 hash_map.0.as_str().ok_or_else(|| {

--- a/rash_core/src/modules/template.rs
+++ b/rash_core/src/modules/template.rs
@@ -64,10 +64,10 @@ fn parse_params(yaml: Yaml) -> Result<Params> {
 fn render_content(params: Params, vars: Vars) -> Result<CopyParams> {
     let mut tera = Tera::default();
     tera.add_template_file(Path::new(&params.src), None)
-        .or_else(|e| Err(Error::new(ErrorKind::InvalidData, e)))?;
+        .map_err(|e| Error::new(ErrorKind::InvalidData, e))?;
     Ok(CopyParams::new(
         tera.render(&params.src, &vars)
-            .or_else(|e| Err(Error::new(ErrorKind::InvalidData, e)))?,
+            .map_err(|e| Error::new(ErrorKind::InvalidData, e))?,
         params.dest.clone(),
         params.mode,
     ))

--- a/rash_core/src/task/mod.rs
+++ b/rash_core/src/task/mod.rs
@@ -313,8 +313,8 @@ impl Task {
 
 pub fn read_file(tasks_file_path: PathBuf) -> Result<Tasks> {
     trace!("reading tasks from: {:?}", tasks_file_path);
-    let tasks_file = fs::read_to_string(tasks_file_path)
-        .or_else(|e| Err(Error::new(ErrorKind::InvalidData, e)))?;
+    let tasks_file =
+        fs::read_to_string(tasks_file_path).map_err(|e| Error::new(ErrorKind::InvalidData, e))?;
 
     let docs = YamlLoader::load_from_str(&tasks_file)?;
     let yaml = docs.first().ok_or_else(|| {

--- a/rash_core/src/utils/mod.rs
+++ b/rash_core/src/utils/mod.rs
@@ -7,9 +7,9 @@ use yaml_rust::{Yaml, YamlLoader};
 
 pub fn parse_octal(s: &str) -> Result<u32> {
     match s.len() {
-        3 => u32::from_str_radix(&s, 8).or_else(|e| Err(Error::new(ErrorKind::InvalidData, e))),
+        3 => u32::from_str_radix(&s, 8).map_err(|e| Error::new(ErrorKind::InvalidData, e)),
         4 => u32::from_str_radix(s.get(1..).unwrap(), 8)
-            .or_else(|e| Err(Error::new(ErrorKind::InvalidData, e))),
+            .map_err(|e| Error::new(ErrorKind::InvalidData, e)),
         _ => Err(Error::new(
             ErrorKind::InvalidData,
             format!("{} cannot be parsed to octal", s),
@@ -18,8 +18,7 @@ pub fn parse_octal(s: &str) -> Result<u32> {
 }
 
 pub fn get_yaml(s: &str) -> Result<Yaml> {
-    let doc =
-        YamlLoader::load_from_str(&s).or_else(|e| Err(Error::new(ErrorKind::InvalidData, e)))?;
+    let doc = YamlLoader::load_from_str(&s).map_err(|e| Error::new(ErrorKind::InvalidData, e))?;
     Ok(doc.first().unwrap().clone())
 }
 

--- a/rash_core/src/utils/tera.rs
+++ b/rash_core/src/utils/tera.rs
@@ -8,7 +8,7 @@ pub fn render_string(s: &str, vars: Vars) -> Result<String> {
     let mut tera = Tera::default();
     trace!("rendering {:?}", &s);
     tera.render_str(s, &vars)
-        .or_else(|e| Err(Error::new(ErrorKind::InvalidData, e)))
+        .map_err(|e| Error::new(ErrorKind::InvalidData, e))
 }
 
 #[inline(always)]

--- a/rash_core/src/vars/env.rs
+++ b/rash_core/src/vars/env.rs
@@ -37,7 +37,7 @@ pub fn load(envars: Vec<(String, String)>) -> Result<Vars> {
     trace!("{:?}", envars);
     envars.into_iter().for_each(|(k, v)| env::set_var(k, v));
     Ok(Context::from_serialize(&Env::from(env::vars()))
-        .or_else(|e| Err(Error::new(ErrorKind::InvalidData, e)))?)
+        .map_err(|e| Error::new(ErrorKind::InvalidData, e))?)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Fix `cargo clippy` errors and `cargo fmt` errors. Mainly subtitute
`.or_else(|e| Err({{ error }} ))` by `.map_err(|e| {{ error }})`.