### PR TITLE
core: update rust to 1.50

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE=ekidd/rust-musl-builder:1.46.0
+ARG BASE_IMAGE=ekidd/rust-musl-builder:1.50.0
 FROM ${BASE_IMAGE} AS builder
 LABEL mantainer pando855@gmail.com
 

--- a/Dockerfile.debian
+++ b/Dockerfile.debian
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE=rust:1.46
+ARG BASE_IMAGE=rust:1.50
 FROM ${BASE_IMAGE} AS builder
 LABEL mantainer pando855@gmail.com
 

--- a/mdbook_rash/src/lib.rs
+++ b/mdbook_rash/src/lib.rs
@@ -24,7 +24,7 @@ lazy_static! {
     .unwrap();
 }
 
-fn get_matches<'a>(ch: &'a Chapter) -> Option<Vec<(Match<'a>, String, String)>> {
+fn get_matches(ch: &Chapter) -> Option<Vec<(Match, String, String)>> {
     RE.captures_iter(&ch.content)
         .map(|cap| match (cap.get(0), cap.get(1), cap.get(2)) {
             (Some(origin), Some(typ), Some(rest)) => match (typ.as_str(), rest.as_str()) {


### PR DESCRIPTION
Fix `cargo clippy` error `needless_lifetimes`.