### PR TITLE
ci: Update `_data/projects.json` on gh-pages deploy

### DIFF
--- a/.commitlintrc.json
+++ b/.commitlintrc.json
@@ -16,7 +16,7 @@
         "tera",
         "lookup",
         "module",
-	      "release",
+        "release",
         "task",
         "vars"
       ]

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -28,12 +28,18 @@ jobs:
 
       - run: |
           make mdbook-rash
-          git clone --depth=1 https://github.com/rash-sh/rash-sh.github.io.git ./rash_book/rash-sh.github.io
+
+          GH_PAGES_DIR=./rash_book/rash-sh.github.io
+          git clone --depth=1 https://github.com/rash-sh/rash-sh.github.io.git $GH_PAGES_DIR
 
           # Strip git ref prefix from version
           VERSION=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')
 
           VERSION=$VERSION make book
+
+          # update _data/projects.json
+          cd $GH_PAGES_DIR
+          make _data/projects.json
 
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v3


### PR DESCRIPTION
This is necessary to include new versions website.