### PR TITLE
fix(ci): Publish packages to crates.io

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,9 +45,11 @@ push-images: build-images
 .PHONY: update-version
 update-version: ## update version from VERSION file in all Cargo.toml manifests
 update-version: */Cargo.toml
-	@VERSION=`cat VERSION`; sed -i "0,/^version\ \= .*$$/{s//version = \"$$VERSION\"/}" */Cargo.toml
-	@cargo update -p rash_core -p rash_derive
-	@echo updated to version "`cat VERSION`" cargo files
+	@VERSION=$$(cat VERSION); \
+	sed -i "0,/^version\ \= .*$$/{s//version = \"$$VERSION\"/}" */Cargo.toml && \
+	sed -i -E "s/^(rash\_.*version\s=\s)\"(.*)\"/\1\"$$VERSION\"/gm" */Cargo.toml && \
+	cargo update -p rash_core -p rash_derive && \
+	echo updated to version "$$(cat VERSION)" cargo files
 
 .PHONY: build
 build:	## compile rash

--- a/mdbook_rash/Cargo.toml
+++ b/mdbook_rash/Cargo.toml
@@ -15,7 +15,7 @@ path = "src/bin/mdbook-rash.rs"
 doc = false
 
 [dependencies]
-rash_core = { path = "../rash_core", features = ["docs"] }
+rash_core = { path = "../rash_core", features = ["docs"], version = "1.3.1" }
 schemars = "0.8"
 clap = "2"
 chrono = "0.4"

--- a/rash_core/Cargo.toml
+++ b/rash_core/Cargo.toml
@@ -21,7 +21,7 @@ path = "src/bin/rash.rs"
 docs = ["rash_derive/docs", "schemars"]
 
 [dependencies]
-rash_derive = { path = "../rash_derive" }
+rash_derive = { path = "../rash_derive", version = "1.3.1" }
 byte-unit = "4.0"
 console = "0.14.0"
 clap = { version = "3.0.0-rc.1", features = ["std", "color", "derive", "cargo"]}


### PR DESCRIPTION
Add version for internal dependencies. This is needed fro crates.io to
allow upload packages.
Also, add auto update these versions in the Makefile as its done for the
others.