### PR TITLE
feat(module): Rename `transfer_pid_1` to `transfer_pid` in command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,15 +2,20 @@
 
 ## unreleased
 
+### To be removed in v1.9.0
+
+* Command module: `transfer_pid_1` (use `transfer_pid` instead)
+
 ### Added
 
+* Rename `transfer_pid_1` to `transfer_pid` in command module
 * Add module debug (#241)
 
 ## [v1.6.1](https://github.com/rash-sh/rash/tree/v1.6.1) (2022-01-22)
 
 ### Fixed
 
-* Options variables are now accessible. (#236)
+* Options variables are now accessible (#236)
 * Update to Rust 1.58.1
 
 ## [v1.6.0](https://github.com/rash-sh/rash/tree/v1.6.0) (2022-01-20)

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Declarative: `entrypoint.rh`
 
 - name: launch docker CMD
   command: {{ rash.argv }}
-  transfer_pid_1: yes
+  transfer_pid: yes
   env:
     APP1_API_KEY: "{{ lookup('vault', env.VAULT_SECRET_PATH ) }}"
 ```

--- a/examples/envar-api-gateway/entrypoint.rh
+++ b/examples/envar-api-gateway/entrypoint.rh
@@ -16,4 +16,4 @@
 
 - command:
     argv: [nginx, '-g', 'daemon off;']
-    transfer_pid_1: true
+    transfer_pid: true

--- a/examples/php-fpm/entrypoint.rh
+++ b/examples/php-fpm/entrypoint.rh
@@ -15,5 +15,5 @@
 - name: "Run php-fpm"
   command:
     cmd: "echo fake-php-fpm"
-    transfer_pid_1: true
+    transfer_pid: true
 

--- a/examples/recursivity.rh
+++ b/examples/recursivity.rh
@@ -13,10 +13,10 @@
 
 - command:
     cmd: "echo done"
-    transfer_pid_1: true
+    transfer_pid: true
   when: env | get(key="MY_PASSWORD")
 
-- name: last command must send with transfer_pid_1 to let it as PID 1
+- name: last command must send with transfer_pid to let it as PID 1
   command:
     argv:
       - /usr/bin/env
@@ -24,4 +24,4 @@
       - -eMY_PASSWORD=supersecret
       - -eTITLE=finish execution
       - "{{ rash.path }}"
-    transfer_pid_1: true
+    transfer_pid: true

--- a/rash_core/src/task/mod.rs
+++ b/rash_core/src/task/mod.rs
@@ -290,7 +290,7 @@ impl Task {
 
                     if user.uid != Uid::current() {
                         if self.module.get_name() == "command"
-                            && rendered_params["transfer_pid_1"].as_bool().unwrap_or(false)
+                            && rendered_params["transfer_pid"].as_bool().unwrap_or(false)
                         {
                             return self.exec_module_rendered_with_user(
                                 &rendered_params,


### PR DESCRIPTION
`transfer_pid_1` will be removed in 1.9.0. From now on is deprecated.