### PR TITLE
fix(ci): remove arm musl builds

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -50,9 +50,7 @@ jobs:
       fail-fast: false
       matrix:
         job:
-          - { os: ubuntu-20.04, target: arm-unknown-linux-musleabihf, use-cross: true }
           - { os: ubuntu-20.04, target: arm-unknown-linux-gnueabihf, use-cross: true }
-          - { os: ubuntu-20.04, target: aarch64-unknown-linux-musl, use-cross: true }
           - { os: ubuntu-20.04, target: aarch64-unknown-linux-gnu, use-cross: true }
           - { os: ubuntu-20.04, target: x86_64-unknown-linux-musl, use-cross: true }
           - { os: ubuntu-20.04, target: x86_64-unknown-linux-gnu, container: quay.io/pypa/manylinux2014_x86_64}


### PR DESCRIPTION
It fails in `rash_core/src/vars/builtin.rs:88` `canonicalize` returning
e.g. `/usr/local/aarch64-linux-musl`.