### PR TITLE
fix(core): Improve docopt performance prefiltering possible options

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,8 @@ members = [
     "rash_derive",
     "mdbook_rash",
 ]
+resolver = "2"
+
 
 [workspace.package]
 version = "1.8.6"


### PR DESCRIPTION
This makes docopt usable when many options are defined.