### PR TITLE
fix(task): Add serde to handle result from fork in become tasks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v2.7.2](https://github.com/rash-sh/rash/tree/v2.7.2) - 2024-09-16
+
+### Fixed
+
+- task: Add serde to handle result from fork in become tasks
+
+### Documentation
+
+- lookup: Add example and comments to passwordstore examples
+- Add to changelog missing info for v2.7.1
+
+### Refactor
+
+- vars: Simplify the builtin vars implementation
+
 ## [v2.7.1](https://github.com/rash-sh/rash/tree/v2.7.1) - 2024-09-15
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1106,7 +1106,7 @@ dependencies = [
 
 [[package]]
 name = "mdbook_rash"
-version = "2.7.1"
+version = "2.7.2"
 dependencies = [
  "chrono",
  "clap",
@@ -1518,7 +1518,7 @@ dependencies = [
 
 [[package]]
 name = "rash_core"
-version = "2.7.1"
+version = "2.7.2"
 dependencies = [
  "byte-unit",
  "cargo-husky",
@@ -1552,7 +1552,7 @@ dependencies = [
 
 [[package]]
 name = "rash_derive"
-version = "2.7.1"
+version = "2.7.2"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 
 
 [workspace.package]
-version = "2.7.1"
+version = "2.7.2"
 authors = ["Pando85 <pando855@gmail.com>"]
 rust-version = "1.80"
 edition = "2021"

--- a/mdbook_rash/Cargo.toml
+++ b/mdbook_rash/Cargo.toml
@@ -15,7 +15,7 @@ path = "src/bin/mdbook-rash.rs"
 doc = false
 
 [dependencies]
-rash_core = { path = "../rash_core", features = ["docs"], version = "2.7.1" }
+rash_core = { path = "../rash_core", features = ["docs"], version = "2.7.2" }
 log.workspace = true
 regex.workspace = true
 schemars.workspace = true

--- a/rash_core/Cargo.toml
+++ b/rash_core/Cargo.toml
@@ -24,7 +24,7 @@ docs = ["rash_derive/docs", "schemars"]
 passwordstore = ["prs-lib"]
 
 [dependencies]
-rash_derive = { path = "../rash_derive", version = "2.7.1" }
+rash_derive = { path = "../rash_derive", version = "2.7.2" }
 log.workspace = true
 regex.workspace = true
 schemars = { workspace = true, optional = true }


### PR DESCRIPTION
Become was broken because the result from the fork was not correctly deserialized into a `minijinja::Value`.