### PR TITLE
build(deps): Remove pinned versions from `Cargo.toml`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,11 +14,11 @@ repository = "https://github.com/rash-sh/rash"
 readme = "README.md"
 
 [workspace.dependencies]
-clap = "4.5.4"
+clap = "4.5"
 log = "0.4.21"
-regex = "1.10.4"
-schemars = "0.8.17"
-serde_json = "1.0.116"
+regex = "1.10"
+schemars = "0.8"
+serde_json = "1.0"
 serde_yaml = "0.9"
 
 [profile.release]

--- a/mdbook_rash/Cargo.toml
+++ b/mdbook_rash/Cargo.toml
@@ -24,6 +24,6 @@ chrono = "0.4.38"
 env_logger = "0.11.3"
 mdbook = { version = "0.4.37", default-features = false }
 prettytable-rs = "^0.10"
-semver = "1.0.22"
+semver = "1.0"
 serde_json.workspace = true
 serde_yaml.workspace = true

--- a/rash_core/Cargo.toml
+++ b/rash_core/Cargo.toml
@@ -30,25 +30,25 @@ regex.workspace = true
 schemars = { workspace = true, optional = true }
 serde_json.workspace = true
 serde_yaml.workspace = true
-byte-unit = "5.1.4"
-console = "0.15.8"
-minijinja = { version = "2.1.2", features = ["loader", "json"]}
-clap = { workspace = true, features = ["std", "color", "derive", "cargo"]}
+byte-unit = "5.1"
+console = "0.15"
+minijinja = { version = "2.2.0", features = ["loader", "json"] }
+clap = { workspace = true, features = ["std", "color", "derive", "cargo"] }
 exec = "0.3.1"
 fern = { version = "0.6.2", features = ["colored"] }
-ignore = "0.4.22"
+ignore = "0.4"
 # memfd brakes compatibility with kernels < 3.17
 ipc-channel = { version = "0.18", features = ["memfd"] }
-itertools = "0.13.0"
-nix = { version = "0.29", features =  ["process", "user"] }
-serde = { version = "1.0.200", features = ["derive"] }
+itertools = "0.13"
+nix = { version = "0.29", features = ["process", "user"] }
+serde = { version = "1.0", features = ["derive"] }
 serde-error = "0.1.2"
-serde_with = "3.8.1"
+serde_with = "3.8"
 shlex = "1.3"
 similar = { version = "2.5", features = ["inline"] }
 strum = "0.26.2"
 strum_macros = "0.26.2"
-tempfile = "3.10.1"
+tempfile = "3.10"
 term_size = "1.0.0-beta.2"
 prs-lib = { version = "0.5.1", optional = true }
 
@@ -61,5 +61,5 @@ harness = false
 
 [dev-dependencies.cargo-husky]
 version = "1.5.0"
-default-features = false # Disable features which are enabled by default
+default-features = false  # Disable features which are enabled by default
 features = ["user-hooks"]

--- a/rash_derive/Cargo.toml
+++ b/rash_derive/Cargo.toml
@@ -13,7 +13,7 @@ repository.workspace = true
 proc-macro = true
 
 [dependencies]
-syn = { version = "2.0.60", features = ["full"] }
+syn = { version = "2.0", features = ["full"] }
 quote = "1.0.36"
 proc-macro2 = "1.0.81"
 schemars = { workspace = true, optional = true }


### PR DESCRIPTION
We should pin minimum required versions in `Cargo.toml`.