### PR TITLE
docs: Fix multiline module parameters table format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v2.10.0](https://github.com/rash-sh/rash/tree/v2.10.0) - 2025-06-15
+
+### Added
+
+- module: Add setup module for loading variables from config files
+
+### Build
+
+- deps: Update Rust crate tempfile to v3.20.0
+- deps: Update Rust crate mdbook to v0.4.51
+- deps: Update Rust crate schemars to 0.9
+- deps: Update Rust crate clap to v4.5.40
+- deps: Update Rust crate syn to v2.0.102
+- deps: Update Rust crate syn to v2.0.103
+- deps: Update Rust crate serde_with to v3.13.0
+
 ## [v2.9.12](https://github.com/rash-sh/rash/tree/v2.9.12) - 2025-06-08
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1134,7 +1134,7 @@ dependencies = [
 
 [[package]]
 name = "mdbook_rash"
-version = "2.9.12"
+version = "2.10.0"
 dependencies = [
  "chrono",
  "clap",
@@ -1597,7 +1597,7 @@ dependencies = [
 
 [[package]]
 name = "rash_core"
-version = "2.9.12"
+version = "2.10.0"
 dependencies = [
  "byte-unit",
  "cargo-husky",
@@ -1632,7 +1632,7 @@ dependencies = [
 
 [[package]]
 name = "rash_derive"
-version = "2.9.12"
+version = "2.10.0"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 
 
 [workspace.package]
-version = "2.9.12"
+version = "2.10.0"
 authors = ["Pando85 <pando855@gmail.com>"]
 rust-version = "1.85"
 edition = "2024"

--- a/mdbook_rash/Cargo.toml
+++ b/mdbook_rash/Cargo.toml
@@ -16,7 +16,7 @@ path = "src/bin/mdbook-rash.rs"
 doc = false
 
 [dependencies]
-rash_core = { path = "../rash_core", features = ["docs"], version = "2.9.12" }
+rash_core = { path = "../rash_core", features = ["docs"], version = "2.10.0" }
 log.workspace = true
 regex.workspace = true
 schemars.workspace = true

--- a/rash_core/Cargo.toml
+++ b/rash_core/Cargo.toml
@@ -25,7 +25,7 @@ docs = ["rash_derive/docs", "schemars"]
 passwordstore = ["prs-lib"]
 
 [dependencies]
-rash_derive = { path = "../rash_derive", version = "2.9.12" }
+rash_derive = { path = "../rash_derive", version = "2.10.0" }
 log.workspace = true
 regex.workspace = true
 schemars = { workspace = true, optional = true }


### PR DESCRIPTION
- Apply oneOf variant descriptions to properties when missing
- Flatten whitespace in descriptions to prevent row splits
- Remove debug code and unused imports