### PR TITLE
fix(core): Keep `vars` scoped to block execution

### DIFF
--- a/examples/rescue_always.rh
+++ b/examples/rescue_always.rh
@@ -54,22 +54,6 @@
       debug:
         msg: "Copy operation attempted to /tmp/test_copy.txt"
 
-- name: Test rescue/always with loop
-  debug:
-    msg: "Processing item: {{ item }}"
-  loop:
-    - item1
-    - item2
-    - item3
-  rescue:
-    - name: Handle loop item failure
-      debug:
-        msg: "Failed processing item: {{ item }}"
-  always:
-    - name: Log processed item
-      debug:
-        msg: "Processed (or attempted to process) item: {{ item }}"
-
 - name: Test nested rescue/always in rescue section
   command:
     cmd: "exit 1"  # This will fail
@@ -117,17 +101,3 @@
     - name: Report findings
       debug:
         msg: "Find operation completed successfully"
-
-- name: Final cleanup
-  file:
-    path: "{{ item }}"
-    state: absent
-  loop:
-    - /tmp/test_file
-    - /tmp/test_copy.txt
-    - /tmp/test_template.txt
-  ignore_errors: true
-  always:
-    - name: Report cleanup completion
-      debug:
-        msg: "Cleanup completed for {{ item }}"

--- a/rash_core/src/bin/rash.rs
+++ b/rash_core/src/bin/rash.rs
@@ -192,7 +192,7 @@ fn main() {
                 Err(e) => crash_error(e),
             };
             trace!("Vars: {new_vars}");
-            match Context::new(tasks, new_vars).exec() {
+            match Context::new(tasks, new_vars, None).exec() {
                 Ok(_) => (),
                 Err(context_error) => match context_error.kind() {
                     ErrorKind::EmptyTaskStack => (),

--- a/rash_core/src/jinja/mod.rs
+++ b/rash_core/src/jinja/mod.rs
@@ -4,8 +4,12 @@ pub mod lookup;
 #[cfg(not(feature = "docs"))]
 mod lookup;
 
-use crate::error::{Error, ErrorKind, Result};
+use crate::{
+    error::{Error, ErrorKind, Result},
+    utils::merge_json,
+};
 use error_utils::handle_template_error;
+use serde::Deserialize;
 
 use std::sync::LazyLock;
 
@@ -122,6 +126,17 @@ pub fn is_render_string(s: &str, vars: &Value) -> Result<bool> {
         "false" => Ok(false),
         _ => Ok(true),
     }
+}
+
+pub fn merge_option(a: Value, b: Option<Value>) -> Value {
+    if let Some(b) = b { merge(a, b) } else { a }
+}
+
+pub fn merge(a: Value, b: Value) -> Value {
+    let mut a_json_value: serde_json::Value = serde_json::Value::deserialize(a).unwrap();
+    let b_json_value: serde_json::Value = serde_json::Value::deserialize(b).unwrap();
+    merge_json(&mut a_json_value, b_json_value);
+    Value::from_serialize(a_json_value)
 }
 
 #[cfg(test)]

--- a/rash_core/src/lib.rs
+++ b/rash_core/src/lib.rs
@@ -35,7 +35,11 @@ mod tests {
             "#;
 
         let global_params = GlobalParams::default();
-        let context = Context::new(parse_file(file, &global_params).unwrap(), env::load(vec![]));
+        let context = Context::new(
+            parse_file(file, &global_params).unwrap(),
+            env::load(vec![]),
+            None,
+        );
         let last_context = context.exec().unwrap();
 
         assert!(last_context.tasks.is_empty());

--- a/rash_core/src/modules/assert.rs
+++ b/rash_core/src/modules/assert.rs
@@ -74,12 +74,12 @@ impl Module for Assert {
         &self,
         _: &GlobalParams,
         optional_params: YamlValue,
-        vars: Value,
+        vars: &Value,
         _check_mode: bool,
-    ) -> Result<(ModuleResult, Value)> {
+    ) -> Result<(ModuleResult, Option<Value>)> {
         Ok((
-            verify_conditions(parse_params(optional_params)?, &vars)?,
-            vars,
+            verify_conditions(parse_params(optional_params)?, vars)?,
+            None,
         ))
     }
 

--- a/rash_core/src/modules/command.rs
+++ b/rash_core/src/modules/command.rs
@@ -73,7 +73,7 @@ pub enum Required {
     Argv(Vec<String>),
 }
 
-fn exec_transferring_pid(params: Params) -> Result<(ModuleResult, Value)> {
+fn exec_transferring_pid(params: Params) -> Result<(ModuleResult, Option<Value>)> {
     let args_vec = match params.required {
         Required::Cmd(s) => s
             .split_whitespace()
@@ -108,9 +108,9 @@ impl Module for Command {
         &self,
         _: &GlobalParams,
         optional_params: YamlValue,
-        vars: Value,
+        _vars: &Value,
         _check_mode: bool,
-    ) -> Result<(ModuleResult, Value)> {
+    ) -> Result<(ModuleResult, Option<Value>)> {
         let params: Params = match optional_params.as_str() {
             Some(s) => Params {
                 chdir: None,
@@ -181,7 +181,7 @@ impl Module for Command {
                             output: module_output,
                             extra,
                         },
-                        vars,
+                        None,
                     ))
                 }
             },

--- a/rash_core/src/modules/copy.rs
+++ b/rash_core/src/modules/copy.rs
@@ -256,10 +256,10 @@ impl Module for Copy {
         &self,
         _: &GlobalParams,
         optional_params: YamlValue,
-        vars: Value,
+        _vars: &Value,
         check_mode: bool,
-    ) -> Result<(ModuleResult, Value)> {
-        Ok((copy_file(parse_params(optional_params)?, check_mode)?, vars))
+    ) -> Result<(ModuleResult, Option<Value>)> {
+        Ok((copy_file(parse_params(optional_params)?, check_mode)?, None))
     }
 
     #[cfg(feature = "docs")]

--- a/rash_core/src/modules/debug.rs
+++ b/rash_core/src/modules/debug.rs
@@ -83,10 +83,10 @@ impl Module for Debug {
         &self,
         _: &GlobalParams,
         optional_params: YamlValue,
-        vars: Value,
+        vars: &Value,
         _check_mode: bool,
-    ) -> Result<(ModuleResult, Value)> {
-        Ok((debug(parse_params(optional_params)?, &vars)?, vars))
+    ) -> Result<(ModuleResult, Option<Value>)> {
+        Ok((debug(parse_params(optional_params)?, vars)?, None))
     }
 
     #[cfg(feature = "docs")]

--- a/rash_core/src/modules/file.rs
+++ b/rash_core/src/modules/file.rs
@@ -321,12 +321,12 @@ impl Module for File {
         &self,
         _: &GlobalParams,
         optional_params: YamlValue,
-        vars: Value,
+        _vars: &Value,
         check_mode: bool,
-    ) -> Result<(ModuleResult, Value)> {
+    ) -> Result<(ModuleResult, Option<Value>)> {
         Ok((
             define_file(parse_params(optional_params)?, check_mode)?,
-            vars,
+            None,
         ))
     }
 

--- a/rash_core/src/modules/find.rs
+++ b/rash_core/src/modules/find.rs
@@ -251,10 +251,10 @@ impl Module for Find {
         &self,
         _: &GlobalParams,
         optional_params: YamlValue,
-        vars: Value,
+        _vars: &Value,
         _check_mode: bool,
-    ) -> Result<(ModuleResult, Value)> {
-        Ok((find(parse_params(optional_params)?)?, vars))
+    ) -> Result<(ModuleResult, Option<Value>)> {
+        Ok((find(parse_params(optional_params)?)?, None))
     }
 
     #[cfg(feature = "docs")]

--- a/rash_core/src/modules/get_url.rs
+++ b/rash_core/src/modules/get_url.rs
@@ -270,9 +270,9 @@ impl Module for GetUrl {
         &self,
         _: &GlobalParams,
         params: YamlValue,
-        vars: Value,
+        _vars: &Value,
         check_mode: bool,
-    ) -> Result<(ModuleResult, Value)> {
+    ) -> Result<(ModuleResult, Option<Value>)> {
         let params: Params = parse_params(params)?;
 
         // Parse destination path
@@ -332,7 +332,7 @@ impl Module for GetUrl {
                     )),
                     extra: None,
                 },
-                vars,
+                None,
             ));
         }
 
@@ -346,7 +346,7 @@ impl Module for GetUrl {
                     )),
                     extra: None,
                 },
-                vars,
+                None,
             ));
         }
 
@@ -464,7 +464,7 @@ impl Module for GetUrl {
                 )),
                 extra,
             },
-            vars,
+            None,
         ))
     }
 

--- a/rash_core/src/modules/include.rs
+++ b/rash_core/src/modules/include.rs
@@ -55,9 +55,9 @@ impl Module for Include {
         &self,
         global_params: &GlobalParams,
         params: YamlValue,
-        vars: Value,
+        vars: &Value,
         _check_mode: bool,
-    ) -> Result<(ModuleResult, Value)> {
+    ) -> Result<(ModuleResult, Option<Value>)> {
         match params {
             YamlValue::String(script_file) => {
                 let script_path = Path::new(&script_file);
@@ -77,9 +77,9 @@ impl Module for Include {
                 let include_vars = context! {rash => &include_builtins, ..vars.clone()};
 
                 trace!("Vars: {include_vars}");
-                Context::new(tasks, include_vars.clone()).exec()?;
+                Context::new(tasks, include_vars.clone(), None).exec()?;
 
-                Ok((ModuleResult::new(false, None, None), vars))
+                Ok((ModuleResult::new(false, None, None), None))
             }
             _ => Err(Error::new(
                 ErrorKind::InvalidData,

--- a/rash_core/src/modules/lineinfile.rs
+++ b/rash_core/src/modules/lineinfile.rs
@@ -229,12 +229,12 @@ impl Module for Lineinfile {
         &self,
         _: &GlobalParams,
         optional_params: YamlValue,
-        vars: Value,
+        _vars: &Value,
         check_mode: bool,
-    ) -> Result<(ModuleResult, Value)> {
+    ) -> Result<(ModuleResult, Option<Value>)> {
         Ok((
             lineinfile(parse_params(optional_params)?, check_mode)?,
-            vars,
+            None,
         ))
     }
 

--- a/rash_core/src/modules/mod.rs
+++ b/rash_core/src/modules/mod.rs
@@ -97,9 +97,9 @@ pub trait Module: Send + Sync + std::fmt::Debug {
         &self,
         global_params: &GlobalParams,
         params: YamlValue,
-        vars: Value,
+        vars: &Value,
         check_mode: bool,
-    ) -> Result<(ModuleResult, Value)>;
+    ) -> Result<(ModuleResult, Option<Value>)>;
 
     /// Determines if the module requires its parameters to be treated as strings.
     ///

--- a/rash_core/src/modules/pacman.rs
+++ b/rash_core/src/modules/pacman.rs
@@ -158,10 +158,10 @@ impl Module for Pacman {
         &self,
         _: &GlobalParams,
         optional_params: YamlValue,
-        vars: Value,
+        _vars: &Value,
         check_mode: bool,
-    ) -> Result<(ModuleResult, Value)> {
-        Ok((pacman(parse_params(optional_params)?, check_mode)?, vars))
+    ) -> Result<(ModuleResult, Option<Value>)> {
+        Ok((pacman(parse_params(optional_params)?, check_mode)?, None))
     }
 
     fn force_string_on_params(&self) -> bool {

--- a/rash_core/src/modules/set_vars.rs
+++ b/rash_core/src/modules/set_vars.rs
@@ -59,10 +59,10 @@ impl Module for SetVars {
         &self,
         _: &GlobalParams,
         params: YamlValue,
-        vars: Value,
+        vars: &Value,
         _check_mode: bool,
-    ) -> Result<(ModuleResult, Value)> {
-        let mut new_vars = vars.clone();
+    ) -> Result<(ModuleResult, Option<Value>)> {
+        let mut new_vars = context! {};
 
         match params {
             YamlValue::Mapping(map) => {
@@ -76,7 +76,7 @@ impl Module for SetVars {
                         })?;
                         let value: Value = [(
                             key,
-                            Value::from_serialize(render(hash_map.1.clone(), &vars)?),
+                            Value::from_serialize(render(hash_map.1.clone(), vars)?),
                         )]
                         .into_iter()
                         .collect();
@@ -99,7 +99,7 @@ impl Module for SetVars {
                 output: None,
                 extra: None,
             },
-            new_vars,
+            Some(new_vars),
         ))
     }
 

--- a/rash_core/src/modules/systemd.rs
+++ b/rash_core/src/modules/systemd.rs
@@ -153,10 +153,10 @@ impl Module for Systemd {
         &self,
         _: &GlobalParams,
         optional_params: YamlValue,
-        vars: Value,
+        _vars: &Value,
         check_mode: bool,
-    ) -> Result<(ModuleResult, Value)> {
-        Ok((systemd(parse_params(optional_params)?, check_mode)?, vars))
+    ) -> Result<(ModuleResult, Option<Value>)> {
+        Ok((systemd(parse_params(optional_params)?, check_mode)?, None))
     }
 
     fn force_string_on_params(&self) -> bool {

--- a/rash_core/src/modules/template.rs
+++ b/rash_core/src/modules/template.rs
@@ -54,7 +54,7 @@ pub struct Params {
     mode: Option<String>,
 }
 
-fn render_content(params: Params, vars: Value) -> Result<CopyParams> {
+fn render_content(params: Params, vars: &Value) -> Result<CopyParams> {
     let mode = match params.mode.as_deref() {
         Some("preserve") => {
             let src_metadata = metadata(&params.src)?;
@@ -66,7 +66,7 @@ fn render_content(params: Params, vars: Value) -> Result<CopyParams> {
     };
 
     Ok(CopyParams {
-        input: Input::Content(render_string(&read_to_string(params.src)?, &vars)?),
+        input: Input::Content(render_string(&read_to_string(params.src)?, vars)?),
         dest: params.dest.clone(),
         mode,
     })
@@ -84,15 +84,15 @@ impl Module for Template {
         &self,
         _: &GlobalParams,
         optional_params: YamlValue,
-        vars: Value,
+        vars: &Value,
         check_mode: bool,
-    ) -> Result<(ModuleResult, Value)> {
+    ) -> Result<(ModuleResult, Option<Value>)> {
         Ok((
             copy_file(
-                render_content(parse_params(optional_params)?, vars.clone())?,
+                render_content(parse_params(optional_params)?, vars)?,
                 check_mode,
             )?,
-            vars,
+            None,
         ))
     }
 
@@ -207,7 +207,7 @@ mod tests {
                 dest: "/tmp/buu.txt".to_owned(),
                 mode: Some("0644".to_owned()),
             },
-            vars,
+            &vars,
         )
         .unwrap();
 
@@ -242,7 +242,7 @@ mod tests {
                 dest: "/tmp/buu.txt".to_owned(),
                 mode: Some("preserve".to_owned()),
             },
-            vars,
+            &vars,
         )
         .unwrap();
 

--- a/rash_core/src/modules/uri.rs
+++ b/rash_core/src/modules/uri.rs
@@ -174,9 +174,9 @@ impl Module for Uri {
         &self,
         _: &GlobalParams,
         params: YamlValue,
-        vars: Value,
+        _vars: &Value,
         _check_mode: bool,
-    ) -> Result<(ModuleResult, Value)> {
+    ) -> Result<(ModuleResult, Option<Value>)> {
         let params: Params = parse_params(params)?;
 
         let response = make_request(&params)?;
@@ -245,7 +245,7 @@ impl Module for Uri {
                 output,
                 extra,
             },
-            vars,
+            None,
         ))
     }
 

--- a/test/modules/block/vars_scoping.rh
+++ b/test/modules/block/vars_scoping.rh
@@ -36,7 +36,7 @@
 - name: Verify block variables don't leak
   assert:
     that:
-      - block_var is defined
+      - block_var is not defined
       - block_task_var is not defined
 
 - name: Verify registered variable persists


### PR DESCRIPTION
Task and module execs were refactored to return new variables. Context has a new attributed for this scoped variables and we can keep the track for new variables in different scopes.

Resolves: #798.