### PR TITLE
fix: correct release skill frontmatter format

### DIFF
--- a/.opencode/skills/release/SKILL.md
+++ b/.opencode/skills/release/SKILL.md
@@ -1,8 +1,7 @@
-name
-release
-
-description
-Guide the release process for rash, including version bumping, changelog updates, and creating release branches.
+---
+name: release
+description: Guide the release process for rash, including version bumping, changelog updates, and creating release branches.
+---
 
 ## Purpose
 


### PR DESCRIPTION
## Summary
- Fix YAML frontmatter format in release skill file (proper `---` delimiters with key: value pairs)