### PR TITLE
fix: handle shallow clones in release script

### DIFF
--- a/.ci/release.sh
+++ b/.ci/release.sh
@@ -1,7 +1,20 @@
 #!/bin/bash
 set -e
 
-if ! [ "$(git rev-list --count origin/master..HEAD)" -eq 0 ]; then
+ensure_full_history() {
+    if git rev-parse --is-shallow-repository 2>/dev/null | grep -q "true"; then
+        echo "Shallow clone detected. Fetching full history and tags..."
+        git fetch --unshallow --quiet
+    fi
+    if [ -z "$(git tag -l)" ]; then
+        echo "No tags found. Fetching tags..."
+        git fetch --tags --quiet
+    fi
+}
+
+ensure_full_history
+
+if ! [ "$(git rev-list --count origin/master..HEAD 2>/dev/null || echo 1)" -eq 0 ]; then
     echo "There are commits in this branch. Please merge them first."
     echo "CHANGELOG template needs master commit ID."
     exit 1

--- a/.opencode/skills/release/SKILL.md
+++ b/.opencode/skills/release/SKILL.md
@@ -77,6 +77,17 @@ git pull origin master
 git status  # Should show "nothing to commit, working tree clean"
 ```
 
+If running in a shallow clone (e.g. CI with `fetch-depth: 1`), fetch full history and tags:
+
+```bash
+if git rev-parse --is-shallow-repository 2>/dev/null | grep -q "true"; then
+    git fetch --unshallow --quiet
+fi
+if [ -z "$(git tag -l)" ]; then
+    git fetch --tags --quiet
+fi
+```
+
 Check that there are no unmerged commits:
 
 ```bash
@@ -185,10 +196,19 @@ After the PR is merged to master:
 | Update changelog | `make update-changelog` |
 | Commit | `git commit -m "release: Version <VER>"` |
 
+## Troubleshooting
+
+### "There are commits in this branch. Please merge them first."
+You're on a branch with unmerged commits. Switch to master and merge first.
+
+### "Shallow clone detected. Fetching full history and tags..."
+The release script detected a shallow clone (e.g. CI with `fetch-depth: 1`). It automatically fetches full history and tags so git-cliff can generate a correct CHANGELOG. No action needed.
+
 ## Checklist
 
 - [ ] On master branch, clean working tree
 - [ ] Pulled latest from origin/master
+- [ ] Shallow clone handled (auto-detected by `.ci/release.sh`)
 - [ ] No unmerged commits (checked with `git rev-list --count origin/master..HEAD`)
 - [ ] Determined version bump type (MAJOR/MINOR/PATCH)
 - [ ] Created release branch `release/v<VERSION>`


### PR DESCRIPTION
## Summary

- Add `ensure_full_history()` to `.ci/release.sh` that detects shallow clones and fetches full history + tags
- Handle `git rev-list` failure when `origin/master` doesn't exist (e.g. shallow clone)
- Update release SKILL.md with shallow clone documentation and troubleshooting

## Why

CI environments often use `fetch-depth: 1` for performance, resulting in shallow clones that lack the full git history and tags needed for:
- `git-cliff` to generate correct CHANGELOGs
- `git rev-list --count origin/master..HEAD` to check for unmerged commits
- Tag-based version comparisons

## Changes

| File | Change |
|------|--------|
| `.ci/release.sh` | Add `ensure_full_history()` function + guard `rev-list` with `2>/dev/null \|\| echo 1` |
| `.opencode/skills/release/SKILL.md` | Document shallow clone handling in Step 1, add troubleshooting section |