### PR TITLE
build: improve release script and update release skill

### DIFF
--- a/.ci/release.sh
+++ b/.ci/release.sh
@@ -1,33 +1,75 @@
 #!/bin/bash
-set -e
+set -euo pipefail
 
 ensure_full_history() {
     if git rev-parse --is-shallow-repository 2>/dev/null | grep -q "true"; then
-        echo "Shallow clone detected. Fetching full history and tags..."
+        echo "Shallow clone detected. Fetching full history..."
         git fetch --unshallow --quiet
     fi
-    if [ -z "$(git tag -l)" ]; then
-        echo "No tags found. Fetching tags..."
-        git fetch --tags --quiet
+    echo "Fetching tags..."
+    git fetch --tags --quiet
+}
+
+ensure_clean_state() {
+    if ! git diff --quiet || ! git diff --cached --quiet; then
+        echo "Working tree is not clean. Commit or stash changes first."
+        exit 1
+    fi
+
+    BRANCH=$(git rev-parse --abbrev-ref HEAD)
+    if [ "$BRANCH" != "master" ]; then
+        echo "Not on master branch. Current branch: $BRANCH"
+        exit 1
+    fi
+
+    git pull origin master --quiet
+
+    if [ "$(git rev-list --count origin/master..HEAD 2>/dev/null || echo 1)" -ne 0 ]; then
+        echo "There are commits ahead of origin/master. Push or merge them first."
+        echo "CHANGELOG template needs master commit ID."
+        exit 1
     fi
 }
 
+echo "=== Checking repository state ==="
+ensure_clean_state
 ensure_full_history
 
-if ! [ "$(git rev-list --count origin/master..HEAD 2>/dev/null || echo 1)" -eq 0 ]; then
-    echo "There are commits in this branch. Please merge them first."
-    echo "CHANGELOG template needs master commit ID."
-    exit 1
+echo ""
+echo "=== Recent commits since last release ==="
+LATEST_TAG=$(git tag --sort=-creatordate | head -1)
+if [ -n "$LATEST_TAG" ]; then
+    git log "$LATEST_TAG"..HEAD --oneline
+else
+    git log --oneline -10
 fi
 
-# bump version
-vim Cargo.toml
+echo ""
+echo "=== Bumping version ==="
+vim ./Cargo.toml
+
+VERSION=$(sed -n 's/^version = "\(.*\)"/\1/p' ./Cargo.toml | head -n1)
+echo "New version: $VERSION"
+
+echo ""
+echo "=== Updating dependencies ==="
 make update-version
 
+echo ""
+echo "=== Updating changelog ==="
 make update-changelog
 
+echo ""
+echo "=== Committing release ==="
 git add .
-VERSION=$(sed -n 's/^version = "\(.*\)"/\1/p' Cargo.toml | head -n1)
 git commit -m "release: Version $VERSION"
 
-echo "After merging the PR, tag and release are automatically done"
+echo ""
+echo "=== Creating release branch and pushing ==="
+git checkout -b "release/v$VERSION"
+git push -u origin "release/v$VERSION"
+
+echo ""
+echo "Release v$VERSION prepared successfully."
+echo "Create a PR to merge release/v$VERSION into master."
+echo "After merge, tag and GitHub release are created automatically."

--- a/.ci/release.sh
+++ b/.ci/release.sh
@@ -1,7 +1,20 @@
 #!/bin/bash
 set -e
 
-if ! [ "$(git rev-list --count origin/master..HEAD)" -eq 0 ]; then
+ensure_full_history() {
+    if git rev-parse --is-shallow-repository 2>/dev/null | grep -q "true"; then
+        echo "Shallow clone detected. Fetching full history and tags..."
+        git fetch --unshallow --quiet
+    fi
+    if [ -z "$(git tag -l)" ]; then
+        echo "No tags found. Fetching tags..."
+        git fetch --tags --quiet
+    fi
+}
+
+ensure_full_history
+
+if ! [ "$(git rev-list --count origin/master..HEAD 2>/dev/null || echo 1)" -eq 0 ]; then
     echo "There are commits in this branch. Please merge them first."
     echo "CHANGELOG template needs master commit ID."
     exit 1

--- a/.opencode/skills/release/SKILL.md
+++ b/.opencode/skills/release/SKILL.md
@@ -180,10 +180,35 @@ Create a pull request to merge into master.
 
 ### Step 9: After Merge
 
-After the PR is merged to master:
+After the PR is merged to master, tagging and releasing is done **automatically** by CI:
 
-1. Create and push a tag: `git tag v<VERSION> && git push origin v<VERSION>`
-2. The CI workflow automatically builds release artifacts and creates a GitHub Release
+1. `auto-tag.yml` reads the new version from `CHANGELOG.md`
+2. Creates a signed GPG tag `v<VERSION>`
+3. Pushes the tag to GitHub
+
+The tag then triggers:
+- `rust.yml`: Builds, tests, publishes to crates.io, creates GitHub Release
+- `docker_images.yml`: Builds/pushes Docker images to ghcr.io
+- `aur-publish.yml`: Publishes AUR packages
+
+Monitor with:
+```bash
+gh run list --limit 5
+```
+
+**Note:** Do not manually create tags — CI handles this automatically.
+
+## What NOT to Do
+
+| Mistake | Why it's wrong | Fix |
+|---------|---------------|-----|
+| Manually editing CHANGELOG.md | git-cliff generates it from conventional commits | Use `make update-changelog` |
+| Creating git tags manually | `auto-tag.yml` creates signed tags automatically | Just push to master |
+| Releasing from a feature branch | Changelog generation needs master commit IDs | Checkout master first |
+| Releasing with dirty working tree | Script will fail or produce incomplete release | Commit or stash changes first |
+| Skipping the unshallow check | Shallow clones produce incomplete changelogs | Always check and unshallow if needed |
+| Forgetting `make update-version` after Cargo.toml edit | Version won't propagate to workspace members | Always run `make update-version` |
+| Using `--amend` on a commit | May amend the wrong parent commit after hook failures | Just commit again normally |
 
 ## Quick Reference
 
@@ -195,6 +220,10 @@ After the PR is merged to master:
 | Update versions | `make update-version` |
 | Update changelog | `make update-changelog` |
 | Commit | `git commit -m "release: Version <VER>"` |
+| Check shallow clone | `git rev-parse --is-shallow-repository` |
+| Unshallow repo | `git fetch --unshallow origin && git fetch --tags origin` |
+| Monitor CI | `gh run list --limit 5` |
+| Run release script | `.ci/release.sh` |
 
 ## Troubleshooting
 
@@ -206,6 +235,7 @@ The release script detected a shallow clone (e.g. CI with `fetch-depth: 1`). It 
 
 ## Checklist
 
+- [ ] Repository is not a shallow clone (or has been unshallowed)
 - [ ] On master branch, clean working tree
 - [ ] Pulled latest from origin/master
 - [ ] Shallow clone handled (auto-detected by `.ci/release.sh`)

--- a/.opencode/skills/release/SKILL.md
+++ b/.opencode/skills/release/SKILL.md
@@ -77,6 +77,17 @@ git pull origin master
 git status  # Should show "nothing to commit, working tree clean"
 ```
 
+If running in a shallow clone (e.g. CI with `fetch-depth: 1`), fetch full history and tags:
+
+```bash
+if git rev-parse --is-shallow-repository 2>/dev/null | grep -q "true"; then
+    git fetch --unshallow --quiet
+fi
+if [ -z "$(git tag -l)" ]; then
+    git fetch --tags --quiet
+fi
+```
+
 Check that there are no unmerged commits:
 
 ```bash
@@ -185,10 +196,19 @@ After the PR is merged to master:
 | Update changelog | `make update-changelog` |
 | Commit | `git commit -m "release: Version <VER>"` |
 
+## Troubleshooting
+
+### "There are commits in this branch. Please merge them first."
+You're on a branch with unmerged commits. Switch to master and merge first.
+
+### "Shallow clone detected. Fetching full history and tags..."
+The release script detected a shallow clone (e.g. CI with `fetch-depth: 1`). It automatically fetches full history and tags so git-cliff can generate a correct CHANGELOG. No action needed.
+
 ## Checklist
 
 - [ ] On master branch, clean working tree
 - [ ] Pulled latest from origin/master
+- [ ] Shallow clone handled (auto-detected by `.ci/release.sh`)
 - [ ] No unmerged commits (checked with `git rev-list --count origin/master..HEAD`)
 - [ ] Determined version bump type (MAJOR/MINOR/PATCH)
 - [ ] Created release branch `release/v<VERSION>`


### PR DESCRIPTION
## Changes

- Improve `.ci/release.sh` with:
  - Clean state validation (branch, dirty tree, commits ahead)
  - Automatic release branch creation and push
  - Better output formatting
- Update `.opencode/skills/release/SKILL.md` with:
  - What NOT to Do table
  - CI auto-tagging documentation in Step 9
  - Expanded quick reference and checklist
- Update `.opencode/.gitignore` to include `package-lock.json`