### PR TITLE
refactor(core): replace script CLI parser with compiled matcher

### DIFF
--- a/.github/workflows/script-cli-benchmark.yml
+++ b/.github/workflows/script-cli-benchmark.yml
@@ -1,0 +1,38 @@
+name: Script CLI parser benchmark
+
+on:
+  push:
+    branches:
+      - refactor/compiled-script-cli-parser
+    paths:
+      - rash_core/src/docopt/**
+      - rash_core/src/script_cli/**
+      - rash_core/benches/docopt.rs
+      - .github/workflows/script-cli-benchmark.yml
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  criterion:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v7
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: script-cli-benchmark
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Benchmark legacy and compiled parsers
+        run: |
+          set -o pipefail
+          cargo bench -p rash_core --bench docopt -- --noplot 2>&1 | tee script-cli-benchmark.txt
+      - name: Upload benchmark results
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: script-cli-benchmark
+          path: |
+            script-cli-benchmark.txt
+            target/criterion
+          if-no-files-found: warn

--- a/rash_core/SCRIPT_CLI_PARSER_REFACTOR.md
+++ b/rash_core/SCRIPT_CLI_PARSER_REFACTOR.md
@@ -32,9 +32,11 @@ These invariants are release gates, not preferences.
 - **Repetition is represented by graph cycles.** `<arg>...` must not duplicate grammar nodes per argument.
 - **Matching is deterministic.** If two successful paths produce different bindings, parsing fails as ambiguous.
 - **Equivalent paths are allowed.** Multiple paths producing identical bindings are not considered ambiguous.
-- **Normalized options preserve aliases.** Short and long forms must resolve to one logical option and output key.
-- **Help still participates in grammar matching.** A declared logical help option may satisfy a positional slot, matching legacy Rash behavior, but it must not globally make an otherwise impossible argv valid.
-- **The replacement does not silently widen the grammar.** Legacy-invalid command, positional, and usage-option identifiers remain invalid unless an intentional syntax change is reviewed separately.
+- **Normalized options preserve aliases.** Short and long forms resolve to one logical option and output key.
+- **Help participates in grammar matching.** `--help`, an alias normalized to `--help`, and the legacy short-only `-h` positional special case are handled through matching; help must not globally make an otherwise impossible argv valid.
+- **The replacement does not silently widen command/positional syntax.** Command and positional identifiers retain the legacy ASCII word grammar.
+- **Option spelling preserves legacy permissiveness.** Option identifiers are not incorrectly constrained by the command/positional word grammar; legacy-accepted option spellings remain accepted.
+- **Nested optional structure is semantic.** Flat `[a b]` retains Rash's independently-optional behavior, while nested forms such as `[command [--option]]` retain the dependency of the nested element on the outer group.
 - **Production switchover is last.** `rash` keeps calling the legacy parser until compatibility and performance gates pass.
 
 ## Phase 0 — Contract capture and baseline
@@ -57,6 +59,7 @@ These invariants are release gates, not preferences.
   - `[options]`;
   - dashed command/argument names;
   - help behavior.
+- [x] Keep legacy comment/help and `Usage:` extraction semantics at the parser boundary so the engine rewrite does not change which declarations become active.
 - [x] Extend Criterion so old and new implementations can be measured side by side.
 
 ### Exit criteria
@@ -88,11 +91,14 @@ These invariants are release gates, not preferences.
 - [x] Analyze symbol multiplicity without expanding patterns.
 - [x] Preserve normalized variable names for dashed commands/positionals.
 - [x] Preserve the legacy lexical domain for command and positional identifiers instead of accepting broader arbitrary atoms.
+- [x] Preserve nested optional dependencies rather than flattening nested brackets into unrelated independent optionals.
 
 ### Correctness checks
 
 - [x] `[a b]` follows Rash's existing independently-optional behavior.
 - [x] `[(a b)]` remains an atomic optional group.
+- [x] `[command [--option]]` allows none, `command`, or `command --option`, but not `--option` alone.
+- [x] Nested positional optionals retain the same outer dependency.
 - [x] `(<a> <b>)...` repeats the complete group and rejects incomplete tails.
 - [x] uppercase positional notation is preserved.
 
@@ -102,7 +108,7 @@ These invariants are release gates, not preferences.
 - AST size is independent of runtime argument count.
 - No option ordering permutations are materialized.
 
-**Status:** complete, pending full CI confirmation.
+**Status:** implementation complete; full CI confirmation pending.
 
 ## Phase 2 — Option registry and argv normalization
 
@@ -122,9 +128,12 @@ These invariants are release gates, not preferences.
   - a value-bearing option at the end of a short cluster.
 - [x] Preserve values containing `=`.
 - [x] Keep repeated simple flags available to the grammar instead of rejecting them globally.
-- [x] Scope `[options]` per usage pattern.
-- [x] Track the logical help option identity without bypassing matching.
-- [x] Reject usage option identifiers outside the legacy lowercase ASCII word grammar.
+- [x] Preserve repeatable value-bearing options as scalar values with legacy last-value-wins behavior instead of converting them to counters or rejecting them.
+- [x] Scope `[options]` per usage pattern as the intended deterministic behavior, rather than reproducing the legacy cross-pattern accumulation bug.
+- [x] Preserve the legacy one-option versus multi-option `[options]` multiplicity behavior.
+- [x] Model help identity separately from the legacy short-only `-h` positional special case.
+- [x] Distinguish `-h --help`, short-only `-h`, and unrelated aliases such as `-h --host` without losing information through normalization.
+- [x] Preserve legacy-permissive option identifiers instead of applying command/positional lexical restrictions to them.
 
 ### Exit criteria
 
@@ -132,8 +141,9 @@ These invariants are release gates, not preferences.
 - Alias spelling does not change output shape.
 - Unknown options produce the same error class as the legacy parser.
 - Registry discovery does not silently reinterpret legacy-simple options as value-bearing options.
+- Repetition changes option output type only where legacy Rash does so.
 
-**Status:** complete, pending differential results.
+**Status:** implementation complete; differential/CI validation pending.
 
 ## Phase 3 — Compiled matcher
 
@@ -144,13 +154,14 @@ These invariants are release gates, not preferences.
 - [x] Compile the AST to an epsilon-NFA.
 - [x] Compile repetition to cycles.
 - [x] Compile unordered optional option groups to masked option loops.
-- [x] Compile `[options]` to a pattern-scoped option loop.
+- [x] Compile `[options]` structurally without materializing option permutations.
+- [x] Preserve the special single-option `[options]` cardinality without giving up structural matching for larger groups.
 - [x] Keep captures in a persistent arena to avoid cloning the complete binding vector per consumed token.
 - [x] Detect different successful binding sets as ambiguity.
 - [x] Deduplicate identical successful binding sets.
-- [x] Preserve legacy help semantics by allowing a logical help option to be consumed through a positional matcher when that positional path is otherwise valid.
-- [ ] Bound active candidates more aggressively by equivalent matcher state where this can be proven semantics-preserving.
-- [ ] Audit epsilon-closure behavior for nullable repeated expressions and reject/normalize grammars that could create zero-consumption cycles.
+- [x] Preserve legacy positional-help matching using alias-aware registry metadata.
+- [x] Audit nullable repetition. Epsilon closure deduplicates `(state, capture-path)` candidates, so zero-consumption cycles terminate; a direct `Repeat(Optional(Positional))` regression test covers zero and multiple consumed values.
+- [ ] Bound active candidates more aggressively by equivalent matcher state **only if** benchmarks show this is useful and capture/ambiguity semantics can be proven unchanged.
 
 ### Complexity targets
 
@@ -164,8 +175,9 @@ These invariants are release gates, not preferences.
 - Pathological repeated-input tests remain bounded.
 - No zero-consumption infinite loops are possible.
 - Ambiguity behavior is deterministic and tested.
+- Any further candidate-state merging is measurement-driven optimization, not a correctness prerequisite.
 
-**Status:** core implementation complete; hardening remains.
+**Status:** correctness hardening implemented; CI and measurement-driven optimization remain.
 
 ## Phase 4 — Differential compatibility campaign
 
@@ -177,23 +189,36 @@ These invariants are release gates, not preferences.
 - [x] repeated positionals;
 - [x] repeated groups;
 - [x] optional sequences and grouped optional sequences;
+- [x] nested optional command/option and command/positional dependencies;
+- [x] nullable optional-repeat forms (`[<x>...]` and `[<x>]...`);
 - [x] option aliases;
 - [x] short clusters;
 - [x] option values and defaults;
+- [x] repeatable value-bearing options and last-value-wins output shape;
 - [x] values containing `=`;
 - [x] unordered adjacent options;
-- [x] `[options]` combinations;
+- [x] `[options]` combinations, including the single-option/multi-option multiplicity distinction;
 - [x] mixed option/command positions;
-- [x] help command, explicit help option, positional-help substitution, and impossible-extra-help cases;
+- [x] help command, explicit help option, positional-help substitution, short-only `-h`, unrelated `-h` aliases, and impossible-extra-help cases;
 - [x] unknown options;
 - [x] overlapping usages with identical bindings;
 - [x] repeated commands/count output parity;
-- [x] optional repeat forms (`[<x>...]` and `[<x>]...`);
 - [x] bounded exhaustive generated argv spaces for representative small grammars;
-- [x] malformed command/positional/usage-option identifier parity cases;
+- [x] malformed command/positional identifier parity cases;
+- [x] permissive legacy option-name characterization cases;
+- [x] legacy one-line/multiline `Usage:` extraction and malformed-spacing boundary cases;
 - [ ] all legacy parser unit-test scenarios mirrored or exercised through the differential suite;
 - [ ] remaining malformed declarations and error-path parity where compatibility matters;
 - [ ] broader fuzz/property-generated grammars if the bounded exhaustive suite reveals gaps worth generalizing.
+
+### Intentional differences already identified
+
+These are not ordinary compatibility failures and must remain explicit:
+
+1. **Pattern-scoped `[options]`.** The legacy implementation accumulates explicit options across usage patterns while expanding `[options]`; the compiled parser scopes the shortcut to the pattern being compiled.
+2. **Deterministic ambiguity errors.** If two successful paths produce different bindings, the compiled parser rejects the declaration instead of selecting a result through iteration order.
+
+Any additional difference requires the same explicit classification before production switchover.
 
 ### Delta policy
 
@@ -208,7 +233,7 @@ Every mismatch must be placed in one of three categories:
 - Differential suite is green for all behavior intended to remain compatible.
 - Any intentional differences are explicitly listed in the PR and covered by tests.
 
-**Status:** in progress; the compatibility corpus is broad enough that the next full semantic CI run is the primary gate.
+**Status:** in progress; the compatibility corpus is broad enough that a full semantic CI run is now the primary gate.
 
 ## Phase 5 — Performance validation and optimization
 
@@ -281,6 +306,7 @@ If the production switch exposes an unresolved compatibility or performance regr
 
 - [ ] Document Rash's supported usage grammar explicitly.
 - [ ] Keep Docopt described as inspiration/history, not compatibility commitment.
+- [ ] Document flat versus nested optional semantics.
 - [ ] Document option ordering, repetition, grouping, aliases, defaults, and help semantics.
 - [ ] Document ambiguity errors.
 - [ ] Add examples for non-trivial supported grammar.
@@ -337,12 +363,12 @@ Updated: 2026-08-28
 
 | Phase | State | Notes |
 | --- | --- | --- |
-| 0. Contract/baseline | Complete | Legacy kept as oracle; differential and Criterion harnesses exist. |
-| 1. Grammar model | Complete / CI validation | AST, multiplicity analysis, and legacy identifier grammar are implemented. |
-| 2. Options/argv normalization | Complete / parity validation | Includes aliases, clusters, declaration-driven value arity, `[options]`, logical help identity, and legacy usage-option identifier validation. |
-| 3. Compiled matcher | In progress | Epsilon-NFA, persistent captures, ambiguity detection, and positional help semantics implemented; candidate/nullable-cycle hardening remains. |
-| 4. Differential compatibility | In progress | Legacy matrices, malformed-grammar cases, and bounded exhaustive argv enumeration are committed; full semantic CI is the immediate gate. |
-| 5. Performance | In progress | Side-by-side benchmarks added; numbers and optimizations pending. |
+| 0. Contract/baseline | Complete | Legacy kept as oracle; differential/benchmark harnesses exist; legacy declaration extraction is pinned. |
+| 1. Grammar model | Complete / CI validation | AST, multiplicity analysis, lexical compatibility, and nested-optional dependency lowering are implemented. |
+| 2. Options/argv normalization | Complete / parity validation | Aliases, clusters, declaration-driven arity, permissive option names, repeatable value options, `[options]` multiplicity, and alias-aware help identity are implemented. |
+| 3. Compiled matcher | Complete / CI + perf validation | Epsilon-NFA, persistent captures, ambiguity detection, option groups, positional help, and nullable-cycle safety are implemented. Further candidate merging is benchmark-driven only. |
+| 4. Differential compatibility | In progress | Broad legacy matrices, malformed/boundary cases, nested optionals, and bounded exhaustive argv enumeration are committed; full semantic CI is the immediate gate. |
+| 5. Performance | In progress | Side-by-side benchmarks added; measurements and any resulting optimizations pending. |
 | 6. Production integration | Blocked on phases 4–5 | No runtime switch yet. |
 | 7. Documentation | Not started | Starts after semantics stabilize. |
 | 8. Legacy cleanup | Deferred | Decision after production validation. |

--- a/rash_core/SCRIPT_CLI_PARSER_REFACTOR.md
+++ b/rash_core/SCRIPT_CLI_PARSER_REFACTOR.md
@@ -33,7 +33,7 @@ These invariants are release gates, not preferences.
 - **Matching is deterministic.** If two successful paths produce different bindings, parsing fails as ambiguous.
 - **Equivalent paths are allowed.** Multiple paths producing identical bindings are not considered ambiguous.
 - **Normalized options preserve aliases.** Short and long forms must resolve to one logical option and output key.
-- **Help short-circuits grammar validation.** A declared help option keeps legacy graceful-exit behavior even if required operands are absent.
+- **Help still participates in grammar matching.** A declared logical help option may satisfy a positional slot, matching legacy Rash behavior, but it must not globally make an otherwise impossible argv valid.
 - **Production switchover is last.** `rash` keeps calling the legacy parser until compatibility and performance gates pass.
 
 ## Phase 0 — Contract capture and baseline
@@ -110,6 +110,8 @@ These invariants are release gates, not preferences.
 
 - [x] Build a single registry for short/long aliases.
 - [x] Parse option defaults and value arity from declarations/help text.
+- [x] Infer value arity from `Usage:` adjacency when no option description supplies it (`-o FILE`, `--env VALUE`, and a value-bearing option at the tail of a short cluster).
+- [x] Allow a description to define value arity even when `Usage:` omits the value placeholder, preserving legacy behavior such as `[--type]` plus `--type=TYPE` in the option description.
 - [x] Normalize:
   - `--name=value`;
   - `--name value`;
@@ -119,7 +121,7 @@ These invariants are release gates, not preferences.
 - [x] Preserve values containing `=`.
 - [x] Keep repeated simple flags available to the grammar instead of rejecting them globally.
 - [x] Scope `[options]` per usage pattern.
-- [x] Add declared-help detection before full grammar matching.
+- [x] Track the logical help option identity without bypassing matching.
 
 ### Exit criteria
 
@@ -142,6 +144,7 @@ These invariants are release gates, not preferences.
 - [x] Keep captures in a persistent arena to avoid cloning the complete binding vector per consumed token.
 - [x] Detect different successful binding sets as ambiguity.
 - [x] Deduplicate identical successful binding sets.
+- [x] Preserve legacy help semantics by allowing a logical help option to be consumed through a positional matcher when that positional path is otherwise valid.
 - [ ] Bound active candidates more aggressively by equivalent matcher state where this can be proven semantics-preserving.
 - [ ] Audit epsilon-closure behavior for nullable repeated expressions and reject/normalize grammars that could create zero-consumption cycles.
 
@@ -177,14 +180,15 @@ These invariants are release gates, not preferences.
 - [x] unordered adjacent options;
 - [x] `[options]` combinations;
 - [x] mixed option/command positions;
-- [x] help command and help option;
+- [x] help command, explicit help option, positional-help substitution, and impossible-extra-help cases;
 - [x] unknown options;
 - [x] overlapping usages with identical bindings;
+- [x] repeated commands/count output parity;
+- [x] optional repeat forms (`[<x>...]` and `[<x>]...`);
+- [x] bounded exhaustive generated argv spaces for representative small grammars;
 - [ ] all legacy parser unit-test scenarios mirrored or exercised through the differential suite;
-- [ ] repeated commands/count output parity;
-- [ ] optional repeat forms (`[<x>...]` and `[<x>]...`);
 - [ ] malformed declarations and error-path parity where compatibility matters;
-- [ ] fuzz/property-generated small grammars and argv combinations, if practical within this PR.
+- [ ] broader fuzz/property-generated grammars if the bounded exhaustive suite reveals gaps worth generalizing.
 
 ### Delta policy
 
@@ -199,7 +203,7 @@ Every mismatch must be placed in one of three categories:
 - Differential suite is green for all behavior intended to remain compatible.
 - Any intentional differences are explicitly listed in the PR and covered by tests.
 
-**Status:** in progress.
+**Status:** in progress; the compatibility corpus is broad enough that the next full semantic CI run is the primary gate.
 
 ## Phase 5 — Performance validation and optimization
 
@@ -330,9 +334,9 @@ Updated: 2026-08-28
 | --- | --- | --- |
 | 0. Contract/baseline | Complete | Legacy kept as oracle; differential and Criterion harnesses exist. |
 | 1. Grammar model | Complete / CI validation | AST and multiplicity analysis implemented. |
-| 2. Options/argv normalization | Complete / parity validation | Includes aliases, clusters, values, `[options]`, and help short-circuit. |
-| 3. Compiled matcher | In progress | Epsilon-NFA and persistent captures implemented; candidate/nullable-cycle hardening remains. |
-| 4. Differential compatibility | In progress | Broad suite present; full semantic CI run is the immediate gate. |
+| 2. Options/argv normalization | Complete / parity validation | Includes aliases, clusters, value arity from descriptions and usage adjacency, `[options]`, and logical help identity. |
+| 3. Compiled matcher | In progress | Epsilon-NFA, persistent captures, ambiguity detection, and positional help semantics implemented; candidate/nullable-cycle hardening remains. |
+| 4. Differential compatibility | In progress | Legacy matrices plus bounded exhaustive argv enumeration are committed; full semantic CI is the immediate gate. |
 | 5. Performance | In progress | Side-by-side benchmarks added; numbers and optimizations pending. |
 | 6. Production integration | Blocked on phases 4–5 | No runtime switch yet. |
 | 7. Documentation | Not started | Starts after semantics stabilize. |

--- a/rash_core/SCRIPT_CLI_PARSER_REFACTOR.md
+++ b/rash_core/SCRIPT_CLI_PARSER_REFACTOR.md
@@ -34,6 +34,7 @@ These invariants are release gates, not preferences.
 - **Equivalent paths are allowed.** Multiple paths producing identical bindings are not considered ambiguous.
 - **Normalized options preserve aliases.** Short and long forms must resolve to one logical option and output key.
 - **Help still participates in grammar matching.** A declared logical help option may satisfy a positional slot, matching legacy Rash behavior, but it must not globally make an otherwise impossible argv valid.
+- **The replacement does not silently widen the grammar.** Legacy-invalid command, positional, and usage-option identifiers remain invalid unless an intentional syntax change is reviewed separately.
 - **Production switchover is last.** `rash` keeps calling the legacy parser until compatibility and performance gates pass.
 
 ## Phase 0 — Contract capture and baseline
@@ -86,6 +87,7 @@ These invariants are release gates, not preferences.
 - [x] Normalize adjacent optional options into an unordered option group instead of generating permutations.
 - [x] Analyze symbol multiplicity without expanding patterns.
 - [x] Preserve normalized variable names for dashed commands/positionals.
+- [x] Preserve the legacy lexical domain for command and positional identifiers instead of accepting broader arbitrary atoms.
 
 ### Correctness checks
 
@@ -109,12 +111,12 @@ These invariants are release gates, not preferences.
 ### Work
 
 - [x] Build a single registry for short/long aliases.
-- [x] Parse option defaults and value arity from declarations/help text.
-- [x] Infer value arity from `Usage:` adjacency when no option description supplies it (`-o FILE`, `--env VALUE`, and a value-bearing option at the tail of a short cluster).
+- [x] Parse option defaults and value arity from declarations/help text and inline option syntax.
 - [x] Allow a description to define value arity even when `Usage:` omits the value placeholder, preserving legacy behavior such as `[--type]` plus `--type=TYPE` in the option description.
+- [x] Do **not** infer new value arity merely from an adjacent non-option word in `Usage:` when no declaration supplies it; legacy Rash does not do that.
 - [x] Normalize:
   - `--name=value`;
-  - `--name value`;
+  - `--name value` when the option is known to take a value;
   - short aliases;
   - short clusters;
   - a value-bearing option at the end of a short cluster.
@@ -122,12 +124,14 @@ These invariants are release gates, not preferences.
 - [x] Keep repeated simple flags available to the grammar instead of rejecting them globally.
 - [x] Scope `[options]` per usage pattern.
 - [x] Track the logical help option identity without bypassing matching.
+- [x] Reject usage option identifiers outside the legacy lowercase ASCII word grammar.
 
 ### Exit criteria
 
 - Matching consumes normalized logical option tokens, not raw spelling variants.
 - Alias spelling does not change output shape.
 - Unknown options produce the same error class as the legacy parser.
+- Registry discovery does not silently reinterpret legacy-simple options as value-bearing options.
 
 **Status:** complete, pending differential results.
 
@@ -186,8 +190,9 @@ These invariants are release gates, not preferences.
 - [x] repeated commands/count output parity;
 - [x] optional repeat forms (`[<x>...]` and `[<x>]...`);
 - [x] bounded exhaustive generated argv spaces for representative small grammars;
+- [x] malformed command/positional/usage-option identifier parity cases;
 - [ ] all legacy parser unit-test scenarios mirrored or exercised through the differential suite;
-- [ ] malformed declarations and error-path parity where compatibility matters;
+- [ ] remaining malformed declarations and error-path parity where compatibility matters;
 - [ ] broader fuzz/property-generated grammars if the bounded exhaustive suite reveals gaps worth generalizing.
 
 ### Delta policy
@@ -333,10 +338,10 @@ Updated: 2026-08-28
 | Phase | State | Notes |
 | --- | --- | --- |
 | 0. Contract/baseline | Complete | Legacy kept as oracle; differential and Criterion harnesses exist. |
-| 1. Grammar model | Complete / CI validation | AST and multiplicity analysis implemented. |
-| 2. Options/argv normalization | Complete / parity validation | Includes aliases, clusters, value arity from descriptions and usage adjacency, `[options]`, and logical help identity. |
+| 1. Grammar model | Complete / CI validation | AST, multiplicity analysis, and legacy identifier grammar are implemented. |
+| 2. Options/argv normalization | Complete / parity validation | Includes aliases, clusters, declaration-driven value arity, `[options]`, logical help identity, and legacy usage-option identifier validation. |
 | 3. Compiled matcher | In progress | Epsilon-NFA, persistent captures, ambiguity detection, and positional help semantics implemented; candidate/nullable-cycle hardening remains. |
-| 4. Differential compatibility | In progress | Legacy matrices plus bounded exhaustive argv enumeration are committed; full semantic CI is the immediate gate. |
+| 4. Differential compatibility | In progress | Legacy matrices, malformed-grammar cases, and bounded exhaustive argv enumeration are committed; full semantic CI is the immediate gate. |
 | 5. Performance | In progress | Side-by-side benchmarks added; numbers and optimizations pending. |
 | 6. Production integration | Blocked on phases 4–5 | No runtime switch yet. |
 | 7. Documentation | Not started | Starts after semantics stabilize. |

--- a/rash_core/SCRIPT_CLI_PARSER_REFACTOR.md
+++ b/rash_core/SCRIPT_CLI_PARSER_REFACTOR.md
@@ -1,0 +1,346 @@
+# Script CLI parser refactor plan
+
+This document is the execution plan and progress log for replacing Rash's current usage-expansion
+based script CLI parser with a compiled matcher.
+
+The refactor is intentionally staged. The legacy parser remains available as an oracle until the new
+implementation has demonstrated compatibility, bounded complexity, and acceptable performance.
+
+## Objectives
+
+1. Preserve the existing Rash script CLI contract for valid, deterministic interfaces.
+2. Remove argument-count-driven and combinatorial usage expansion from the parsing architecture.
+3. Make ambiguous declarations deterministic failures instead of relying on collection iteration order.
+4. Keep long repeated argument lists and large option sets cheap enough for entrypoint/bootstrap use.
+5. Make the supported grammar explicit and maintainable instead of inheriting accidental Docopt behavior.
+6. Switch production only after differential tests and benchmarks provide evidence that the replacement is safe.
+
+## Non-goals
+
+- Full Docopt compatibility.
+- Redesigning Rash's top-level interpreter/script argument boundary.
+- Changing the JSON/template variable contract as part of the parser rewrite.
+- Adding new CLI syntax solely because the new grammar can represent it.
+- Removing the legacy parser before it has finished serving as the differential-test and benchmark oracle.
+
+## Architectural invariants
+
+These invariants are release gates, not preferences.
+
+- **No concrete usage expansion.** Grammar size must depend on the declaration, not on `argv` length.
+- **No factorial option permutation generation.** Unordered optional options must be represented structurally.
+- **Repetition is represented by graph cycles.** `<arg>...` must not duplicate grammar nodes per argument.
+- **Matching is deterministic.** If two successful paths produce different bindings, parsing fails as ambiguous.
+- **Equivalent paths are allowed.** Multiple paths producing identical bindings are not considered ambiguous.
+- **Normalized options preserve aliases.** Short and long forms must resolve to one logical option and output key.
+- **Help short-circuits grammar validation.** A declared help option keeps legacy graceful-exit behavior even if required operands are absent.
+- **Production switchover is last.** `rash` keeps calling the legacy parser until compatibility and performance gates pass.
+
+## Phase 0 — Contract capture and baseline
+
+**Goal:** establish what must be preserved before changing production behavior.
+
+### Work
+
+- [x] Keep `docopt::parse` intact as the reference implementation.
+- [x] Add a public `script_cli::parse` entry point beside it.
+- [x] Build differential-test helpers that compare values and error kinds.
+- [x] Capture representative real-world grammar shapes:
+  - command alternatives;
+  - repeatable positional arguments;
+  - repeated groups;
+  - short and long option aliases;
+  - short option clusters;
+  - options carrying values;
+  - defaults;
+  - `[options]`;
+  - dashed command/argument names;
+  - help behavior.
+- [x] Extend Criterion so old and new implementations can be measured side by side.
+
+### Exit criteria
+
+- Legacy parser remains untouched and callable.
+- Differential tests cover the main currently-supported syntax classes.
+- Benchmarks can invoke both implementations with identical inputs.
+
+**Status:** complete.
+
+## Phase 1 — Grammar model
+
+**Goal:** replace string rewriting with an explicit parser grammar.
+
+### Work
+
+- [x] Tokenize usage declarations.
+- [x] Introduce an AST for:
+  - sequence;
+  - alternative;
+  - optional;
+  - required grouping;
+  - repetition;
+  - command literals;
+  - positional arguments;
+  - option references;
+  - `[options]`.
+- [x] Normalize adjacent optional options into an unordered option group instead of generating permutations.
+- [x] Analyze symbol multiplicity without expanding patterns.
+- [x] Preserve normalized variable names for dashed commands/positionals.
+
+### Correctness checks
+
+- [x] `[a b]` follows Rash's existing independently-optional behavior.
+- [x] `[(a b)]` remains an atomic optional group.
+- [x] `(<a> <b>)...` repeats the complete group and rejects incomplete tails.
+- [x] uppercase positional notation is preserved.
+
+### Exit criteria
+
+- Every supported declaration is represented as a bounded AST.
+- AST size is independent of runtime argument count.
+- No option ordering permutations are materialized.
+
+**Status:** complete, pending full CI confirmation.
+
+## Phase 2 — Option registry and argv normalization
+
+**Goal:** separate lexical option handling from grammar matching.
+
+### Work
+
+- [x] Build a single registry for short/long aliases.
+- [x] Parse option defaults and value arity from declarations/help text.
+- [x] Normalize:
+  - `--name=value`;
+  - `--name value`;
+  - short aliases;
+  - short clusters;
+  - a value-bearing option at the end of a short cluster.
+- [x] Preserve values containing `=`.
+- [x] Keep repeated simple flags available to the grammar instead of rejecting them globally.
+- [x] Scope `[options]` per usage pattern.
+- [x] Add declared-help detection before full grammar matching.
+
+### Exit criteria
+
+- Matching consumes normalized logical option tokens, not raw spelling variants.
+- Alias spelling does not change output shape.
+- Unknown options produce the same error class as the legacy parser.
+
+**Status:** complete, pending differential results.
+
+## Phase 3 — Compiled matcher
+
+**Goal:** make runtime matching proportional to input and active grammar states rather than generated usage combinations.
+
+### Work
+
+- [x] Compile the AST to an epsilon-NFA.
+- [x] Compile repetition to cycles.
+- [x] Compile unordered optional option groups to masked option loops.
+- [x] Compile `[options]` to a pattern-scoped option loop.
+- [x] Keep captures in a persistent arena to avoid cloning the complete binding vector per consumed token.
+- [x] Detect different successful binding sets as ambiguity.
+- [x] Deduplicate identical successful binding sets.
+- [ ] Bound active candidates more aggressively by equivalent matcher state where this can be proven semantics-preserving.
+- [ ] Audit epsilon-closure behavior for nullable repeated expressions and reject/normalize grammars that could create zero-consumption cycles.
+
+### Complexity targets
+
+- Grammar compilation: `O(grammar size)` apart from registry lookups.
+- Repeatable argv: no grammar growth with argument count.
+- Matching: target `O(argv * active states)` with bounded state/capture bookkeeping.
+- No factorial or exponential pre-expansion as an implementation strategy.
+
+### Exit criteria
+
+- Pathological repeated-input tests remain bounded.
+- No zero-consumption infinite loops are possible.
+- Ambiguity behavior is deterministic and tested.
+
+**Status:** core implementation complete; hardening remains.
+
+## Phase 4 — Differential compatibility campaign
+
+**Goal:** characterize every semantic delta before production switch.
+
+### Test matrix
+
+- [x] basic commands and alternatives;
+- [x] repeated positionals;
+- [x] repeated groups;
+- [x] optional sequences and grouped optional sequences;
+- [x] option aliases;
+- [x] short clusters;
+- [x] option values and defaults;
+- [x] values containing `=`;
+- [x] unordered adjacent options;
+- [x] `[options]` combinations;
+- [x] mixed option/command positions;
+- [x] help command and help option;
+- [x] unknown options;
+- [x] overlapping usages with identical bindings;
+- [ ] all legacy parser unit-test scenarios mirrored or exercised through the differential suite;
+- [ ] repeated commands/count output parity;
+- [ ] optional repeat forms (`[<x>...]` and `[<x>]...`);
+- [ ] malformed declarations and error-path parity where compatibility matters;
+- [ ] fuzz/property-generated small grammars and argv combinations, if practical within this PR.
+
+### Delta policy
+
+Every mismatch must be placed in one of three categories:
+
+1. **Compatibility bug in the new parser** — fix before switchover.
+2. **Nondeterministic/incorrect legacy behavior** — document and add an explicit regression test for the intended correction.
+3. **Unsupported accidental Docopt behavior** — do not silently drop it; document the decision and keep production on legacy until the compatibility policy is accepted.
+
+### Exit criteria
+
+- Differential suite is green for all behavior intended to remain compatible.
+- Any intentional differences are explicitly listed in the PR and covered by tests.
+
+**Status:** in progress.
+
+## Phase 5 — Performance validation and optimization
+
+**Goal:** prove the new architecture is at least suitable for Rash's local automation workloads and materially better on pathological grammar shapes.
+
+### Benchmarks
+
+- [x] repeatable arguments at 10 / 100 / 1,000 / 10,000 elements;
+- [x] large Pacman-style option declaration;
+- [x] `[options]` with larger option sets;
+- [x] nested alternatives;
+- [ ] compile-only cost separated from match cost where useful;
+- [ ] success and failure paths;
+- [ ] ambiguous grammar path;
+- [ ] repeated option clusters;
+- [ ] capture-heavy long argv.
+
+### Optimization order
+
+Only optimize from measurements, in this order:
+
+1. eliminate accidental allocations/clones in the hot match loop;
+2. merge equivalent active states when capture semantics permit it;
+3. replace general-purpose hash structures with indexed/bitset structures where stable IDs already exist;
+4. cache epsilon closures or precompute closure transitions if profiling shows closure traversal is significant;
+5. consider a denser compiled instruction representation only if the NFA object model itself is measurable overhead.
+
+### Performance gates
+
+- No regression large enough to matter on normal small Rash scripts without a documented reason.
+- Clear improvement over legacy behavior on combinatorial option/alternative cases.
+- Near-linear behavior for long repeated argv.
+- 10,000 repeated arguments must remain practical and must not trigger grammar expansion or quadratic capture copying.
+
+### Exit criteria
+
+- Criterion numbers are recorded in the PR.
+- Any regression is explained and either fixed or consciously accepted.
+
+**Status:** benchmark harness present; measurements/optimization pending.
+
+## Phase 6 — Production integration
+
+**Goal:** switch Rash only after the replacement has earned it.
+
+### Work
+
+- [ ] Change production script parsing from `docopt::parse` to `script_cli::parse`.
+- [ ] Run all existing examples using the new parser.
+- [ ] Run integration tests that exercise scripts through the actual `rash` binary.
+- [ ] Confirm error/help output remains usable at the CLI boundary.
+- [ ] Keep the legacy parser available for differential tests and benchmarks for the remainder of this PR unless retaining it creates production coupling.
+
+### Rollback condition
+
+If the production switch exposes an unresolved compatibility or performance regression, revert only the switchover commit and continue development with both implementations side by side.
+
+### Exit criteria
+
+- Actual Rash execution uses the compiled parser.
+- Full behavior suite remains green.
+
+**Status:** not started by design.
+
+## Phase 7 — Documentation and supported-language definition
+
+**Goal:** stop describing Rash as if it inherits the complete Docopt language by implication.
+
+### Work
+
+- [ ] Document Rash's supported usage grammar explicitly.
+- [ ] Keep Docopt described as inspiration/history, not compatibility commitment.
+- [ ] Document option ordering, repetition, grouping, aliases, defaults, and help semantics.
+- [ ] Document ambiguity errors.
+- [ ] Add examples for non-trivial supported grammar.
+- [ ] Update terminology from implementation-specific `docopt` wording where appropriate.
+
+### Exit criteria
+
+- Users can understand the supported syntax without consulting Docopt internals.
+- Intentional incompatibilities are discoverable.
+
+**Status:** not started.
+
+## Phase 8 — Removal/cleanup decision
+
+**Goal:** decide what happens to the legacy implementation after confidence is established.
+
+### Options
+
+- Keep legacy only behind tests/benchmarks for one release cycle.
+- Move selected legacy fixtures into permanent compatibility tests and remove the implementation.
+- Remove legacy immediately only if the differential corpus is comprehensive enough and keeping it meaningfully increases maintenance cost.
+
+### Work
+
+- [ ] Make the decision after the production parser is green across CI and benchmark results are known.
+- [ ] Remove dead expansion helpers if the legacy implementation is removed.
+- [ ] Rename modules/files only after behavior has stabilized; avoid mixing large naming churn with semantic debugging.
+
+**Status:** deferred.
+
+## Phase 9 — Final release gate
+
+The PR must not leave draft until all applicable items below are true.
+
+- [ ] `cargo fmt --check` green.
+- [ ] Clippy green with warnings denied.
+- [ ] MSRV (`1.94.1` at the start of this refactor) green.
+- [ ] Linux GNU tests green.
+- [ ] Linux musl build/tests green where exercised by CI.
+- [ ] AArch64 Linux green.
+- [ ] Apple Silicon/macOS green.
+- [ ] FreeBSD build green.
+- [ ] Pre-commit green.
+- [ ] Release-image workflow green or any unrelated failure explicitly identified.
+- [ ] Differential compatibility suite green.
+- [ ] Benchmarks reviewed and summarized in the PR.
+- [ ] Production switch completed and tested.
+- [ ] Documentation updated.
+- [ ] Final diff reviewed for accidental scope creep.
+
+## Current progress
+
+Updated: 2026-08-28
+
+| Phase | State | Notes |
+| --- | --- | --- |
+| 0. Contract/baseline | Complete | Legacy kept as oracle; differential and Criterion harnesses exist. |
+| 1. Grammar model | Complete / CI validation | AST and multiplicity analysis implemented. |
+| 2. Options/argv normalization | Complete / parity validation | Includes aliases, clusters, values, `[options]`, and help short-circuit. |
+| 3. Compiled matcher | In progress | Epsilon-NFA and persistent captures implemented; candidate/nullable-cycle hardening remains. |
+| 4. Differential compatibility | In progress | Broad suite present; full semantic CI run is the immediate gate. |
+| 5. Performance | In progress | Side-by-side benchmarks added; numbers and optimizations pending. |
+| 6. Production integration | Blocked on phases 4–5 | No runtime switch yet. |
+| 7. Documentation | Not started | Starts after semantics stabilize. |
+| 8. Legacy cleanup | Deferred | Decision after production validation. |
+| 9. Final release gate | Not started | PR remains draft. |
+
+## Progress-update policy
+
+This file is the durable progress record for the refactor. Update the table and relevant phase checkboxes
+when a phase gate changes materially, not for every tiny implementation commit. The PR body should stay
+high-level and link to this document rather than duplicating every detail.

--- a/rash_core/benches/docopt.rs
+++ b/rash_core/benches/docopt.rs
@@ -5,7 +5,7 @@ use criterion::{
     criterion_main,
 };
 
-use rash_core::docopt::parse;
+use rash_core::{docopt, script_cli};
 
 fn run_docopt_arguments(c: &mut Criterion) {
     let file = r#"
@@ -16,16 +16,18 @@ fn run_docopt_arguments(c: &mut Criterion) {
     "#;
 
     let plot_config = PlotConfiguration::default().summary_scale(AxisScale::Logarithmic);
-
-    let mut group = c.benchmark_group("run_docopt_arguments");
+    let mut group = c.benchmark_group("script_cli_arguments");
     group.measurement_time(Duration::from_secs(25));
     group.plot_config(plot_config);
 
-    for args_len in [10, 100, 1000, 10000].iter() {
-        let args = vec!["foo"; args_len.to_owned()];
-        group.throughput(Throughput::Elements(*args_len as u64));
-        group.bench_with_input(BenchmarkId::from_parameter(args_len), &args, |b, args| {
-            b.iter(|| parse(file, args).unwrap());
+    for args_len in [10, 100, 1000, 10000] {
+        let args = vec!["foo"; args_len];
+        group.throughput(Throughput::Elements(args_len as u64));
+        group.bench_with_input(BenchmarkId::new("legacy", args_len), &args, |b, args| {
+            b.iter(|| docopt::parse(file, args).unwrap());
+        });
+        group.bench_with_input(BenchmarkId::new("compiled", args_len), &args, |b, args| {
+            b.iter(|| script_cli::parse(file, args).unwrap());
         });
     }
     group.finish();
@@ -85,8 +87,7 @@ fn run_docopt_options(c: &mut Criterion) {
 #      --sysroot        operate on a mounted guest system (root-only)
 #      --help
     "#;
-    let mut group = c.benchmark_group("run_docopt_options");
-
+    let mut group = c.benchmark_group("script_cli_options");
     group.measurement_time(Duration::from_secs(25));
     let args = vec![
         "-b",
@@ -134,14 +135,109 @@ fn run_docopt_options(c: &mut Criterion) {
         "yea",
         "--sysroot",
     ];
-    group.bench_with_input(
-        BenchmarkId::from_parameter("all options"),
-        &args,
-        |b, args| {
-            b.iter(|| parse(file, args).unwrap());
-        },
-    );
 
+    group.bench_with_input(BenchmarkId::new("legacy", "pacman"), &args, |b, args| {
+        b.iter(|| docopt::parse(file, args).unwrap());
+    });
+    group.bench_with_input(BenchmarkId::new("compiled", "pacman"), &args, |b, args| {
+        b.iter(|| script_cli::parse(file, args).unwrap());
+    });
+    group.finish();
+}
+
+fn run_optional_option_scaling(c: &mut Criterion) {
+    let cases = [
+        (
+            "8-options",
+            r#"
+#!/usr/bin/env rash
+#
+# Usage: tool [options] <target>
+#
+# Options:
+#   -a --alpha    alpha
+#   -b --beta     beta
+#   -c --charlie  charlie
+#   -d --delta    delta
+#   -e --echo     echo
+#   -f --foxtrot  foxtrot
+#   -g --golf     golf
+#   -h --hotel    hotel
+#
+"#,
+            vec!["--hotel", "--alpha", "--golf", "--charlie", "target"],
+        ),
+        (
+            "16-options",
+            r#"
+#!/usr/bin/env rash
+#
+# Usage: tool [options] <target>
+#
+# Options:
+#   -a --alpha     alpha
+#   -b --beta      beta
+#   -c --charlie   charlie
+#   -d --delta     delta
+#   -e --echo      echo
+#   -f --foxtrot   foxtrot
+#   -g --golf      golf
+#   -h --hotel     hotel
+#   -i --india     india
+#   -j --juliet    juliet
+#   -k --kilo      kilo
+#   -l --lima      lima
+#   -m --mike      mike
+#   -n --november  november
+#   -o --oscar     oscar
+#   -p --papa      papa
+#
+"#,
+            vec![
+                "--papa",
+                "--alpha",
+                "--november",
+                "--charlie",
+                "--lima",
+                "--echo",
+                "--hotel",
+                "--juliet",
+                "target",
+            ],
+        ),
+    ];
+
+    let mut group = c.benchmark_group("script_cli_optional_option_scaling");
+    for (name, file, args) in cases {
+        group.bench_with_input(BenchmarkId::new("legacy", name), &args, |b, args| {
+            b.iter(|| docopt::parse(file, args).unwrap());
+        });
+        group.bench_with_input(BenchmarkId::new("compiled", name), &args, |b, args| {
+            b.iter(|| script_cli::parse(file, args).unwrap());
+        });
+    }
+    group.finish();
+}
+
+fn run_nested_alternatives(c: &mut Criterion) {
+    let file = r#"
+#!/usr/bin/env rash
+#
+# Usage:
+#   tool ((start | stop) (api | worker) (fast | safe)) [--force] <target>
+#
+# Options:
+#   --force  force
+#
+"#;
+    let args = vec!["start", "worker", "safe", "--force", "node"];
+    let mut group = c.benchmark_group("script_cli_nested_alternatives");
+    group.bench_function("legacy", |b| {
+        b.iter(|| docopt::parse(file, &args).unwrap());
+    });
+    group.bench_function("compiled", |b| {
+        b.iter(|| script_cli::parse(file, &args).unwrap());
+    });
     group.finish();
 }
 
@@ -150,5 +246,5 @@ criterion_group!(name = docopt;
     .sample_size(10)
     .warm_up_time(Duration::from_secs(3))
     .with_plots();
-    targets = run_docopt_arguments, run_docopt_options);
+    targets = run_docopt_arguments, run_docopt_options, run_optional_option_scaling, run_nested_alternatives);
 criterion_main!(docopt);

--- a/rash_core/src/lib.rs
+++ b/rash_core/src/lib.rs
@@ -7,6 +7,7 @@ pub mod jinja;
 pub mod job;
 pub mod logger;
 pub mod modules;
+pub mod script_cli;
 pub mod task;
 pub mod utils;
 pub mod vars;

--- a/rash_core/src/script_cli/grammar.rs
+++ b/rash_core/src/script_cli/grammar.rs
@@ -357,41 +357,53 @@ impl Parser {
 fn classify_atom(value: String) -> Result<Atom> {
     if value.starts_with('<') {
         let Some(name) = value.strip_prefix('<').and_then(|v| v.strip_suffix('>')) else {
-            return Err(Error::new(
-                ErrorKind::InvalidData,
-                format!("Invalid positional argument: {value}"),
-            ));
+            return Err(invalid_atom(&value));
         };
-        if name.is_empty() {
-            return Err(Error::new(
-                ErrorKind::InvalidData,
-                "Positional argument names cannot be empty",
-            ));
+        if !is_lower_word(name) {
+            return Err(invalid_atom(&value));
         }
         return Ok(Atom::Positional {
             key: normalize_key(name),
         });
     }
 
-    let has_alpha = value.chars().any(char::is_alphabetic);
-    let is_uppercase_positional = has_alpha
-        && value
-            .chars()
-            .all(|c| !c.is_alphabetic() || c.is_uppercase())
-        && value
-            .chars()
-            .all(|c| c.is_alphanumeric() || matches!(c, '_' | '-'));
-
-    if is_uppercase_positional {
+    if is_upper_word(&value) {
         Ok(Atom::Positional {
             key: normalize_key(&value.to_lowercase()),
         })
-    } else {
+    } else if is_lower_word(&value) {
         Ok(Atom::Command {
             key: normalize_key(&value),
             literal: value,
         })
+    } else {
+        Err(invalid_atom(&value))
     }
+}
+
+fn invalid_atom(value: &str) -> Error {
+    Error::new(
+        ErrorKind::InvalidData,
+        format!("Invalid usage identifier: {value}"),
+    )
+}
+
+pub(super) fn is_lower_word(value: &str) -> bool {
+    is_word(value, u8::is_ascii_lowercase)
+}
+
+pub(super) fn is_upper_word(value: &str) -> bool {
+    is_word(value, u8::is_ascii_uppercase)
+}
+
+fn is_word(value: &str, predicate: fn(&u8) -> bool) -> bool {
+    if value.is_empty() {
+        return false;
+    }
+
+    value
+        .split(['_', '-'])
+        .all(|segment| !segment.is_empty() && segment.as_bytes().iter().all(predicate))
 }
 
 fn normalize_key(value: &str) -> String {
@@ -445,5 +457,16 @@ mod tests {
             Expr::Optional(Box::new(Expr::Atom(Atom::Option(2)))),
         ]));
         assert_eq!(expr, Expr::OptionsGroup(vec![1, 2]));
+    }
+
+    #[test]
+    fn identifier_grammar_matches_legacy_ascii_words() {
+        assert!(is_lower_word("daemon-reload"));
+        assert!(is_lower_word("package_filters"));
+        assert!(is_upper_word("UNIT-NAME"));
+        assert!(!is_lower_word("run2"));
+        assert!(!is_lower_word("Run"));
+        assert!(!is_upper_word("FILE2"));
+        assert!(!is_upper_word("File"));
     }
 }

--- a/rash_core/src/script_cli/grammar.rs
+++ b/rash_core/src/script_cli/grammar.rs
@@ -226,12 +226,9 @@ fn normalize_option_groups(expr: Expr) -> Expr {
                 _ => Expr::Sequence(out),
             }
         }
-        Expr::Alternative(items) => Expr::Alternative(
-            items
-                .into_iter()
-                .map(normalize_option_groups)
-                .collect(),
-        ),
+        Expr::Alternative(items) => {
+            Expr::Alternative(items.into_iter().map(normalize_option_groups).collect())
+        }
         Expr::Optional(inner) => Expr::Optional(Box::new(normalize_option_groups(*inner))),
         Expr::Required(inner) => Expr::Required(Box::new(normalize_option_groups(*inner))),
         Expr::Repeat(inner) => Expr::Repeat(Box::new(normalize_option_groups(*inner))),
@@ -378,7 +375,9 @@ fn classify_atom(value: String) -> Result<Atom> {
 
     let has_alpha = value.chars().any(char::is_alphabetic);
     let is_uppercase_positional = has_alpha
-        && value.chars().all(|c| !c.is_alphabetic() || c.is_uppercase())
+        && value
+            .chars()
+            .all(|c| !c.is_alphabetic() || c.is_uppercase())
         && value
             .chars()
             .all(|c| c.is_alphanumeric() || matches!(c, '_' | '-'));

--- a/rash_core/src/script_cli/grammar.rs
+++ b/rash_core/src/script_cli/grammar.rs
@@ -1,0 +1,376 @@
+use std::collections::{BTreeMap, HashMap, HashSet};
+
+use crate::error::{Error, ErrorKind, Result};
+
+use super::Token;
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(super) enum Atom {
+    Command { literal: String, key: String },
+    Positional { key: String },
+    Option(usize),
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(super) enum Expr {
+    Empty,
+    Atom(Atom),
+    Sequence(Vec<Expr>),
+    Alternative(Vec<Expr>),
+    Optional(Box<Expr>),
+    Repeat(Box<Expr>),
+    OptionsShortcut,
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub(super) struct Metadata {
+    pub command_repeated: BTreeMap<String, bool>,
+    pub positional_repeated: BTreeMap<String, bool>,
+    pub repeatable_options: HashSet<usize>,
+}
+
+#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+enum Symbol {
+    Command(String),
+    Positional(String),
+    Option(usize),
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum Count {
+    Finite(usize),
+    Unbounded,
+}
+
+impl Count {
+    fn add(self, other: Self) -> Self {
+        match (self, other) {
+            (Self::Unbounded, _) | (_, Self::Unbounded) => Self::Unbounded,
+            (Self::Finite(a), Self::Finite(b)) => Self::Finite(a.saturating_add(b)),
+        }
+    }
+
+    fn max(self, other: Self) -> Self {
+        match (self, other) {
+            (Self::Unbounded, _) | (_, Self::Unbounded) => Self::Unbounded,
+            (Self::Finite(a), Self::Finite(b)) => Self::Finite(a.max(b)),
+        }
+    }
+
+    fn repeated(self) -> bool {
+        matches!(self, Self::Unbounded | Self::Finite(2..))
+    }
+
+    fn present(self) -> bool {
+        !matches!(self, Self::Finite(0))
+    }
+}
+
+pub(super) fn parse(tokens: Vec<Token>) -> Result<Expr> {
+    let mut parser = Parser { tokens, pos: 0 };
+    let expr = parser.parse_alternative()?;
+    if parser.pos != parser.tokens.len() {
+        return Err(parser.invalid("unexpected trailing token"));
+    }
+    Ok(expr)
+}
+
+pub(super) fn analyze(patterns: &[Expr]) -> Metadata {
+    let mut total = HashMap::<Symbol, Count>::new();
+
+    for pattern in patterns {
+        merge_max(&mut total, occurrences(pattern));
+    }
+
+    let mut metadata = Metadata::default();
+    for (symbol, count) in total {
+        match symbol {
+            Symbol::Command(key) => {
+                metadata.command_repeated.insert(key, count.repeated());
+            }
+            Symbol::Positional(key) => {
+                metadata.positional_repeated.insert(key, count.repeated());
+            }
+            Symbol::Option(id) if count.repeated() => {
+                metadata.repeatable_options.insert(id);
+            }
+            Symbol::Option(_) => {}
+        }
+    }
+    metadata
+}
+
+pub(super) fn explicit_options(expr: &Expr) -> HashSet<usize> {
+    let mut out = HashSet::new();
+    collect_explicit_options(expr, &mut out);
+    out
+}
+
+fn collect_explicit_options(expr: &Expr, out: &mut HashSet<usize>) {
+    match expr {
+        Expr::Atom(Atom::Option(id)) => {
+            out.insert(*id);
+        }
+        Expr::Sequence(items) | Expr::Alternative(items) => {
+            for item in items {
+                collect_explicit_options(item, out);
+            }
+        }
+        Expr::Optional(inner) | Expr::Repeat(inner) => collect_explicit_options(inner, out),
+        Expr::Empty | Expr::Atom(_) | Expr::OptionsShortcut => {}
+    }
+}
+
+fn occurrences(expr: &Expr) -> HashMap<Symbol, Count> {
+    match expr {
+        Expr::Empty | Expr::OptionsShortcut => HashMap::new(),
+        Expr::Atom(atom) => {
+            let symbol = match atom {
+                Atom::Command { key, .. } => Symbol::Command(key.clone()),
+                Atom::Positional { key } => Symbol::Positional(key.clone()),
+                Atom::Option(id) => Symbol::Option(*id),
+            };
+            HashMap::from([(symbol, Count::Finite(1))])
+        }
+        Expr::Sequence(items) => {
+            let mut out = HashMap::new();
+            for item in items {
+                merge_add(&mut out, occurrences(item));
+            }
+            out
+        }
+        Expr::Alternative(items) => {
+            let mut out = HashMap::new();
+            for item in items {
+                merge_max(&mut out, occurrences(item));
+            }
+            out
+        }
+        Expr::Optional(inner) => occurrences(inner),
+        Expr::Repeat(inner) => occurrences(inner)
+            .into_iter()
+            .map(|(symbol, count)| {
+                let count = if count.present() {
+                    Count::Unbounded
+                } else {
+                    Count::Finite(0)
+                };
+                (symbol, count)
+            })
+            .collect(),
+    }
+}
+
+fn merge_add(target: &mut HashMap<Symbol, Count>, source: HashMap<Symbol, Count>) {
+    for (symbol, count) in source {
+        target
+            .entry(symbol)
+            .and_modify(|current| *current = current.add(count))
+            .or_insert(count);
+    }
+}
+
+fn merge_max(target: &mut HashMap<Symbol, Count>, source: HashMap<Symbol, Count>) {
+    for (symbol, count) in source {
+        target
+            .entry(symbol)
+            .and_modify(|current| *current = current.max(count))
+            .or_insert(count);
+    }
+}
+
+struct Parser {
+    tokens: Vec<Token>,
+    pos: usize,
+}
+
+impl Parser {
+    fn parse_alternative(&mut self) -> Result<Expr> {
+        let mut branches = vec![self.parse_sequence()?];
+        while self.consume_if(&Token::Pipe) {
+            branches.push(self.parse_sequence()?);
+        }
+        Ok(if branches.len() == 1 {
+            branches.pop().unwrap()
+        } else {
+            Expr::Alternative(branches)
+        })
+    }
+
+    fn parse_sequence(&mut self) -> Result<Expr> {
+        let mut items = Vec::new();
+        while let Some(token) = self.peek() {
+            if matches!(token, Token::RightBracket | Token::RightParen | Token::Pipe) {
+                break;
+            }
+            items.push(self.parse_primary()?);
+        }
+        Ok(match items.len() {
+            0 => Expr::Empty,
+            1 => items.pop().unwrap(),
+            _ => Expr::Sequence(items),
+        })
+    }
+
+    fn parse_primary(&mut self) -> Result<Expr> {
+        let token = self
+            .next()
+            .cloned()
+            .ok_or_else(|| self.invalid("unexpected end of usage"))?;
+
+        let mut expr = match token {
+            Token::LeftParen => {
+                let inner = self.parse_alternative()?;
+                self.expect(Token::RightParen)?;
+                inner
+            }
+            Token::LeftBracket => {
+                let inner = self.parse_alternative()?;
+                self.expect(Token::RightBracket)?;
+                if matches!(
+                    &inner,
+                    Expr::Atom(Atom::Command { literal, .. }) if literal == "options"
+                ) {
+                    Expr::OptionsShortcut
+                } else {
+                    Expr::Optional(Box::new(inner))
+                }
+            }
+            Token::Atom(value) => Expr::Atom(classify_atom(value)?),
+            Token::Option(id) => Expr::Atom(Atom::Option(id)),
+            Token::Ellipsis => return Err(self.invalid("ellipsis has no preceding expression")),
+            Token::RightBracket | Token::RightParen | Token::Pipe => {
+                return Err(self.invalid("unexpected delimiter"));
+            }
+        };
+
+        if self.consume_if(&Token::Ellipsis) {
+            expr = Expr::Repeat(Box::new(expr));
+            if self.consume_if(&Token::Ellipsis) {
+                return Err(self.invalid("duplicate ellipsis"));
+            }
+        }
+        Ok(expr)
+    }
+
+    fn expect(&mut self, expected: Token) -> Result<()> {
+        if self.consume_if(&expected) {
+            Ok(())
+        } else {
+            Err(self.invalid(&format!("expected {expected:?}")))
+        }
+    }
+
+    fn consume_if(&mut self, expected: &Token) -> bool {
+        if self.peek() == Some(expected) {
+            self.pos += 1;
+            true
+        } else {
+            false
+        }
+    }
+
+    fn peek(&self) -> Option<&Token> {
+        self.tokens.get(self.pos)
+    }
+
+    fn next(&mut self) -> Option<&Token> {
+        let token = self.tokens.get(self.pos);
+        if token.is_some() {
+            self.pos += 1;
+        }
+        token
+    }
+
+    fn invalid(&self, message: &str) -> Error {
+        Error::new(
+            ErrorKind::InvalidData,
+            format!("Invalid usage grammar at token {}: {message}", self.pos),
+        )
+    }
+}
+
+fn classify_atom(value: String) -> Result<Atom> {
+    if value.starts_with('<') {
+        let Some(name) = value.strip_prefix('<').and_then(|v| v.strip_suffix('>')) else {
+            return Err(Error::new(
+                ErrorKind::InvalidData,
+                format!("Invalid positional argument: {value}"),
+            ));
+        };
+        if name.is_empty() {
+            return Err(Error::new(
+                ErrorKind::InvalidData,
+                "Positional argument names cannot be empty",
+            ));
+        }
+        return Ok(Atom::Positional {
+            key: normalize_key(name),
+        });
+    }
+
+    let has_alpha = value.chars().any(char::is_alphabetic);
+    let is_uppercase_positional = has_alpha
+        && value.chars().all(|c| {
+            !c.is_alphabetic() || c.is_uppercase()
+        })
+        && value
+            .chars()
+            .all(|c| c.is_alphanumeric() || matches!(c, '_' | '-'));
+
+    if is_uppercase_positional {
+        Ok(Atom::Positional {
+            key: normalize_key(&value.to_lowercase()),
+        })
+    } else {
+        Ok(Atom::Command {
+            key: normalize_key(&value),
+            literal: value,
+        })
+    }
+}
+
+fn normalize_key(value: &str) -> String {
+    value.replace('-', "_")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_nested_usage() {
+        let tokens = vec![
+            Token::Atom("ship".into()),
+            Token::LeftParen,
+            Token::Atom("new".into()),
+            Token::Pipe,
+            Token::Atom("move".into()),
+            Token::RightParen,
+            Token::LeftBracket,
+            Token::Atom("FILE".into()),
+            Token::RightBracket,
+            Token::Ellipsis,
+        ];
+
+        let parsed = parse(tokens).unwrap();
+        assert!(matches!(parsed, Expr::Sequence(_)));
+    }
+
+    #[test]
+    fn metadata_tracks_repetition_without_expansion() {
+        let expr = Expr::Sequence(vec![
+            Expr::Atom(Atom::Command {
+                literal: "copy".into(),
+                key: "copy".into(),
+            }),
+            Expr::Repeat(Box::new(Expr::Atom(Atom::Positional {
+                key: "source".into(),
+            }))),
+        ]);
+
+        let metadata = analyze(&[expr]);
+        assert_eq!(metadata.command_repeated.get("copy"), Some(&false));
+        assert_eq!(metadata.positional_repeated.get("source"), Some(&true));
+    }
+}

--- a/rash_core/src/script_cli/grammar.rs
+++ b/rash_core/src/script_cli/grammar.rs
@@ -256,7 +256,7 @@ impl Parser {
     fn parse_alternative(&mut self) -> Result<Expr> {
         let mut branches = vec![self.parse_sequence()?];
         while self.consume_if(&Token::Pipe) {
-            branches.push(self.parse_sequence()?];
+            branches.push(self.parse_sequence()?);
         }
         Ok(if branches.len() == 1 {
             branches.pop().unwrap()

--- a/rash_core/src/script_cli/grammar.rs
+++ b/rash_core/src/script_cli/grammar.rs
@@ -236,6 +236,17 @@ fn normalize_option_groups(expr: Expr) -> Expr {
     }
 }
 
+fn contains_nested_optional(expr: &Expr) -> bool {
+    match expr {
+        Expr::Optional(_) | Expr::OptionsShortcut => true,
+        Expr::Sequence(items) | Expr::Alternative(items) => {
+            items.iter().any(contains_nested_optional)
+        }
+        Expr::Required(inner) | Expr::Repeat(inner) => contains_nested_optional(inner),
+        Expr::Empty | Expr::Atom(_) | Expr::OptionsGroup(_) => false,
+    }
+}
+
 struct Parser {
     tokens: Vec<Token>,
     pos: usize,
@@ -245,7 +256,7 @@ impl Parser {
     fn parse_alternative(&mut self) -> Result<Expr> {
         let mut branches = vec![self.parse_sequence()?];
         while self.consume_if(&Token::Pipe) {
-            branches.push(self.parse_sequence()?);
+            branches.push(self.parse_sequence()?];
         }
         Ok(if branches.len() == 1 {
             branches.pop().unwrap()
@@ -290,12 +301,16 @@ impl Parser {
                 ) {
                     Expr::OptionsShortcut
                 } else if let Expr::Sequence(items) = inner {
-                    Expr::Sequence(
-                        items
-                            .into_iter()
-                            .map(|item| Expr::Optional(Box::new(item)))
-                            .collect(),
-                    )
+                    if items.iter().any(contains_nested_optional) {
+                        Expr::Optional(Box::new(Expr::Sequence(items)))
+                    } else {
+                        Expr::Sequence(
+                            items
+                                .into_iter()
+                                .map(|item| Expr::Optional(Box::new(item)))
+                                .collect(),
+                        )
+                    }
                 } else {
                     Expr::Optional(Box::new(inner))
                 }
@@ -388,11 +403,11 @@ fn invalid_atom(value: &str) -> Error {
     )
 }
 
-pub(super) fn is_lower_word(value: &str) -> bool {
+fn is_lower_word(value: &str) -> bool {
     is_word(value, u8::is_ascii_lowercase)
 }
 
-pub(super) fn is_upper_word(value: &str) -> bool {
+fn is_upper_word(value: &str) -> bool {
     is_word(value, u8::is_ascii_uppercase)
 }
 
@@ -457,6 +472,32 @@ mod tests {
             Expr::Optional(Box::new(Expr::Atom(Atom::Option(2)))),
         ]));
         assert_eq!(expr, Expr::OptionsGroup(vec![1, 2]));
+    }
+
+    #[test]
+    fn flat_bracket_sequence_remains_independently_optional() {
+        let parsed = parse(vec![
+            Token::LeftBracket,
+            Token::Atom("alpha".into()),
+            Token::Atom("beta".into()),
+            Token::RightBracket,
+        ])
+        .unwrap();
+        assert!(matches!(parsed, Expr::Sequence(_)));
+    }
+
+    #[test]
+    fn nested_optional_keeps_outer_dependency() {
+        let parsed = parse(vec![
+            Token::LeftBracket,
+            Token::Atom("command".into()),
+            Token::LeftBracket,
+            Token::Option(0),
+            Token::RightBracket,
+            Token::RightBracket,
+        ])
+        .unwrap();
+        assert!(matches!(parsed, Expr::Optional(inner) if matches!(*inner, Expr::Sequence(_))));
     }
 
     #[test]

--- a/rash_core/src/script_cli/grammar.rs
+++ b/rash_core/src/script_cli/grammar.rs
@@ -18,7 +18,9 @@ pub(super) enum Expr {
     Sequence(Vec<Expr>),
     Alternative(Vec<Expr>),
     Optional(Box<Expr>),
+    Required(Box<Expr>),
     Repeat(Box<Expr>),
+    OptionsGroup(Vec<usize>),
     OptionsShortcut,
 }
 
@@ -72,7 +74,7 @@ pub(super) fn parse(tokens: Vec<Token>) -> Result<Expr> {
     if parser.pos != parser.tokens.len() {
         return Err(parser.invalid("unexpected trailing token"));
     }
-    Ok(expr)
+    Ok(normalize_option_groups(expr))
 }
 
 pub(super) fn analyze(patterns: &[Expr]) -> Metadata {
@@ -111,12 +113,15 @@ fn collect_explicit_options(expr: &Expr, out: &mut HashSet<usize>) {
         Expr::Atom(Atom::Option(id)) => {
             out.insert(*id);
         }
+        Expr::OptionsGroup(ids) => out.extend(ids.iter().copied()),
         Expr::Sequence(items) | Expr::Alternative(items) => {
             for item in items {
                 collect_explicit_options(item, out);
             }
         }
-        Expr::Optional(inner) | Expr::Repeat(inner) => collect_explicit_options(inner, out),
+        Expr::Optional(inner) | Expr::Required(inner) | Expr::Repeat(inner) => {
+            collect_explicit_options(inner, out)
+        }
         Expr::Empty | Expr::Atom(_) | Expr::OptionsShortcut => {}
     }
 }
@@ -132,6 +137,11 @@ fn occurrences(expr: &Expr) -> HashMap<Symbol, Count> {
             };
             HashMap::from([(symbol, Count::Finite(1))])
         }
+        Expr::OptionsGroup(ids) => ids
+            .iter()
+            .copied()
+            .map(|id| (Symbol::Option(id), Count::Finite(1)))
+            .collect(),
         Expr::Sequence(items) => {
             let mut out = HashMap::new();
             for item in items {
@@ -146,7 +156,7 @@ fn occurrences(expr: &Expr) -> HashMap<Symbol, Count> {
             }
             out
         }
-        Expr::Optional(inner) => occurrences(inner),
+        Expr::Optional(inner) | Expr::Required(inner) => occurrences(inner),
         Expr::Repeat(inner) => occurrences(inner)
             .into_iter()
             .map(|(symbol, count)| {
@@ -176,6 +186,56 @@ fn merge_max(target: &mut HashMap<Symbol, Count>, source: HashMap<Symbol, Count>
             .entry(symbol)
             .and_modify(|current| *current = current.max(count))
             .or_insert(count);
+    }
+}
+
+fn normalize_option_groups(expr: Expr) -> Expr {
+    match expr {
+        Expr::Sequence(items) => {
+            let items = items
+                .into_iter()
+                .map(normalize_option_groups)
+                .collect::<Vec<_>>();
+            let mut out = Vec::with_capacity(items.len());
+            let mut option_run = Vec::new();
+
+            let flush = |out: &mut Vec<Expr>, run: &mut Vec<usize>| {
+                match run.len() {
+                    0 => {}
+                    1 => out.push(Expr::Optional(Box::new(Expr::Atom(Atom::Option(run[0]))))),
+                    _ => out.push(Expr::OptionsGroup(std::mem::take(run))),
+                }
+                run.clear();
+            };
+
+            for item in items {
+                if let Expr::Optional(inner) = &item
+                    && let Expr::Atom(Atom::Option(id)) = inner.as_ref()
+                {
+                    option_run.push(*id);
+                    continue;
+                }
+                flush(&mut out, &mut option_run);
+                out.push(item);
+            }
+            flush(&mut out, &mut option_run);
+
+            match out.len() {
+                0 => Expr::Empty,
+                1 => out.pop().unwrap(),
+                _ => Expr::Sequence(out),
+            }
+        }
+        Expr::Alternative(items) => Expr::Alternative(
+            items
+                .into_iter()
+                .map(normalize_option_groups)
+                .collect(),
+        ),
+        Expr::Optional(inner) => Expr::Optional(Box::new(normalize_option_groups(*inner))),
+        Expr::Required(inner) => Expr::Required(Box::new(normalize_option_groups(*inner))),
+        Expr::Repeat(inner) => Expr::Repeat(Box::new(normalize_option_groups(*inner))),
+        other => other,
     }
 }
 
@@ -222,7 +282,7 @@ impl Parser {
             Token::LeftParen => {
                 let inner = self.parse_alternative()?;
                 self.expect(Token::RightParen)?;
-                inner
+                Expr::Required(Box::new(inner))
             }
             Token::LeftBracket => {
                 let inner = self.parse_alternative()?;
@@ -232,6 +292,13 @@ impl Parser {
                     Expr::Atom(Atom::Command { literal, .. }) if literal == "options"
                 ) {
                     Expr::OptionsShortcut
+                } else if let Expr::Sequence(items) = inner {
+                    Expr::Sequence(
+                        items
+                            .into_iter()
+                            .map(|item| Expr::Optional(Box::new(item)))
+                            .collect(),
+                    )
                 } else {
                     Expr::Optional(Box::new(inner))
                 }
@@ -311,9 +378,7 @@ fn classify_atom(value: String) -> Result<Atom> {
 
     let has_alpha = value.chars().any(char::is_alphabetic);
     let is_uppercase_positional = has_alpha
-        && value.chars().all(|c| {
-            !c.is_alphabetic() || c.is_uppercase()
-        })
+        && value.chars().all(|c| !c.is_alphabetic() || c.is_uppercase())
         && value
             .chars()
             .all(|c| c.is_alphanumeric() || matches!(c, '_' | '-'));
@@ -372,5 +437,14 @@ mod tests {
         let metadata = analyze(&[expr]);
         assert_eq!(metadata.command_repeated.get("copy"), Some(&false));
         assert_eq!(metadata.positional_repeated.get("source"), Some(&true));
+    }
+
+    #[test]
+    fn adjacent_optional_options_become_unordered_group() {
+        let expr = normalize_option_groups(Expr::Sequence(vec![
+            Expr::Optional(Box::new(Expr::Atom(Atom::Option(1)))),
+            Expr::Optional(Box::new(Expr::Atom(Atom::Option(2)))),
+        ]));
+        assert_eq!(expr, Expr::OptionsGroup(vec![1, 2]));
     }
 }

--- a/rash_core/src/script_cli/matcher.rs
+++ b/rash_core/src/script_cli/matcher.rs
@@ -396,10 +396,7 @@ mod tests {
         )))));
         let nfa = compile(&[pattern], &OptionRegistry::default());
         assert!(execute(&nfa, &[]).is_ok());
-        let input = [
-            InputToken::Word("a".into()),
-            InputToken::Word("b".into()),
-        ];
+        let input = [InputToken::Word("a".into()), InputToken::Word("b".into())];
         let captures = execute(&nfa, &input).unwrap();
         assert_eq!(captures.len(), 2);
         assert!(nfa.states.len() < 10);

--- a/rash_core/src/script_cli/matcher.rs
+++ b/rash_core/src/script_cli/matcher.rs
@@ -41,7 +41,7 @@ pub(super) struct Nfa {
     states: Vec<State>,
     start: usize,
     accept: usize,
-    help_option: Option<usize>,
+    positional_help_options: Vec<bool>,
 }
 
 #[derive(Clone, Copy, Debug, Hash, PartialEq, Eq)]
@@ -100,7 +100,7 @@ pub(super) fn compile(patterns: &[Expr], options: &OptionRegistry) -> Nfa {
     let mut builder = Builder::default();
     let start = builder.state();
     let accept = builder.state();
-    let help_option = options.all_ids().find(|id| options.is_help(*id));
+    let positional_help_options = positional_help_options(options);
 
     for pattern in patterns {
         let explicit = grammar::explicit_options(pattern);
@@ -120,8 +120,45 @@ pub(super) fn compile(patterns: &[Expr], options: &OptionRegistry) -> Nfa {
         states: builder.states,
         start,
         accept,
-        help_option,
+        positional_help_options,
     }
+}
+
+fn positional_help_options(options: &OptionRegistry) -> Vec<bool> {
+    let mut mask = vec![false; options.len()];
+    for id in options.all_ids() {
+        if options.is_help(id) {
+            mask[id] = true;
+        }
+    }
+
+    let short_h = options.normalize_args(&["-h"]).ok().and_then(|tokens| {
+        let [InputToken::Option { id, value }] = tokens.as_slice() else {
+            return None;
+        };
+        value.is_none().then_some(*id)
+    });
+
+    if let Some(id) = short_h
+        && !options.is_help(id)
+    {
+        let long_h_same = options
+            .normalize_args(&["--h"])
+            .ok()
+            .and_then(|tokens| {
+                let [InputToken::Option { id, value }] = tokens.as_slice() else {
+                    return None;
+                };
+                value.is_none().then_some(*id)
+            })
+            .is_some_and(|long_id| long_id == id);
+
+        if !long_h_same {
+            mask[id] = true;
+        }
+    }
+
+    mask
 }
 
 pub(super) fn execute(nfa: &Nfa, input: &[InputToken]) -> Result<Vec<Capture>, MatchError> {
@@ -141,7 +178,7 @@ pub(super) fn execute(nfa: &Nfa, input: &[InputToken]) -> Result<Vec<Capture>, M
                 let Edge::Consume { matcher, target } = edge else {
                     continue;
                 };
-                if let Some(capture) = matches(matcher, token, nfa.help_option) {
+                if let Some(capture) = matches(matcher, token, &nfa.positional_help_options) {
                     let path = Some(arena.append(candidate.path, capture));
                     next.push(Candidate {
                         state: *target,
@@ -193,7 +230,11 @@ fn epsilon_closure(nfa: &Nfa, seeds: impl IntoIterator<Item = Candidate>) -> Vec
     out
 }
 
-fn matches(matcher: &Matcher, input: &InputToken, help_option: Option<usize>) -> Option<Capture> {
+fn matches(
+    matcher: &Matcher,
+    input: &InputToken,
+    positional_help_options: &[bool],
+) -> Option<Capture> {
     match (matcher, input) {
         (Matcher::Command { literal, key }, InputToken::Word(value)) if literal == value => {
             Some(Capture::Command(key.clone()))
@@ -203,7 +244,7 @@ fn matches(matcher: &Matcher, input: &InputToken, help_option: Option<usize>) ->
             value: value.clone(),
         }),
         (Matcher::Positional { .. }, InputToken::Option { id, value })
-            if Some(*id) == help_option && value.is_none() =>
+            if positional_help_options.get(*id).copied().unwrap_or(false) && value.is_none() =>
         {
             Some(Capture::Option {
                 id: *id,
@@ -446,6 +487,24 @@ mod tests {
         .unwrap();
         let nfa = compile(&[pattern], &registry);
         let input = registry.normalize_args(&["--help"]).unwrap();
+        assert!(matches!(
+            execute(&nfa, &input),
+            Ok(captures) if matches!(captures.as_slice(), [Capture::Option { .. }])
+        ));
+    }
+
+    #[test]
+    fn short_only_h_can_be_consumed_by_positional_without_becoming_help() {
+        let pattern = Expr::Atom(Atom::Positional {
+            key: "target".into(),
+        });
+        let registry = OptionRegistry::from_doc(
+            "Usage: tool <target>\n\n-h  h flag",
+            &["tool <target>".to_owned()],
+        )
+        .unwrap();
+        let nfa = compile(&[pattern], &registry);
+        let input = registry.normalize_args(&["-h"]).unwrap();
         assert!(matches!(
             execute(&nfa, &input),
             Ok(captures) if matches!(captures.as_slice(), [Capture::Option { .. }])

--- a/rash_core/src/script_cli/matcher.rs
+++ b/rash_core/src/script_cli/matcher.rs
@@ -1,0 +1,350 @@
+use std::collections::{HashMap, HashSet, VecDeque};
+
+use super::grammar::{self, Atom, Expr};
+use super::options::OptionRegistry;
+use super::InputToken;
+
+#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+pub(super) enum Capture {
+    Command(String),
+    Positional { key: String, value: String },
+    Option { id: usize, value: Option<String> },
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(super) enum MatchError {
+    NoMatch,
+    Ambiguous,
+}
+
+#[derive(Clone, Debug)]
+enum Matcher {
+    Command { literal: String, key: String },
+    Positional { key: String },
+    Option(usize),
+    AnyOption(Vec<bool>),
+}
+
+#[derive(Clone, Debug)]
+enum Edge {
+    Epsilon(usize),
+    Consume { matcher: Matcher, target: usize },
+}
+
+#[derive(Clone, Debug, Default)]
+struct State {
+    edges: Vec<Edge>,
+}
+
+#[derive(Clone, Debug)]
+pub(super) struct Nfa {
+    states: Vec<State>,
+    start: usize,
+    accept: usize,
+}
+
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq)]
+struct Candidate {
+    state: usize,
+    path: Option<usize>,
+}
+
+#[derive(Clone, Debug)]
+struct PathNode {
+    prev: Option<usize>,
+    capture: Capture,
+}
+
+#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+struct PathKey {
+    prev: Option<usize>,
+    capture: Capture,
+}
+
+#[derive(Default)]
+struct PathArena {
+    nodes: Vec<PathNode>,
+    intern: HashMap<PathKey, usize>,
+}
+
+impl PathArena {
+    fn append(&mut self, prev: Option<usize>, capture: Capture) -> usize {
+        let key = PathKey {
+            prev,
+            capture: capture.clone(),
+        };
+        if let Some(id) = self.intern.get(&key) {
+            return *id;
+        }
+        let id = self.nodes.len();
+        self.nodes.push(PathNode { prev, capture });
+        self.intern.insert(key, id);
+        id
+    }
+
+    fn materialize(&self, path: Option<usize>) -> Vec<Capture> {
+        let mut out = Vec::new();
+        let mut current = path;
+        while let Some(id) = current {
+            let node = &self.nodes[id];
+            out.push(node.capture.clone());
+            current = node.prev;
+        }
+        out.reverse();
+        out
+    }
+}
+
+pub(super) fn compile(patterns: &[Expr], options: &OptionRegistry) -> Nfa {
+    let mut builder = Builder::default();
+    let start = builder.state();
+    let accept = builder.state();
+
+    for pattern in patterns {
+        let explicit = grammar::explicit_options(pattern);
+        let mut allowed = vec![false; options.len()];
+        for id in options.all_ids() {
+            if !explicit.contains(&id) {
+                allowed[id] = true;
+            }
+        }
+
+        let (pattern_start, pattern_end) = builder.compile_expr(pattern, &allowed);
+        builder.epsilon(start, pattern_start);
+        builder.epsilon(pattern_end, accept);
+    }
+
+    Nfa {
+        states: builder.states,
+        start,
+        accept,
+    }
+}
+
+pub(super) fn execute(nfa: &Nfa, input: &[InputToken]) -> Result<Vec<Capture>, MatchError> {
+    let mut arena = PathArena::default();
+    let mut candidates = epsilon_closure(
+        nfa,
+        [Candidate {
+            state: nfa.start,
+            path: None,
+        }],
+    );
+
+    for token in input {
+        let mut next = Vec::new();
+        for candidate in &candidates {
+            for edge in &nfa.states[candidate.state].edges {
+                let Edge::Consume { matcher, target } = edge else {
+                    continue;
+                };
+                if let Some(capture) = matches(matcher, token) {
+                    let path = Some(arena.append(candidate.path, capture));
+                    next.push(Candidate {
+                        state: *target,
+                        path,
+                    });
+                }
+            }
+        }
+
+        if next.is_empty() {
+            return Err(MatchError::NoMatch);
+        }
+        candidates = epsilon_closure(nfa, next);
+    }
+
+    candidates = epsilon_closure(nfa, candidates);
+    let mut outputs = HashSet::new();
+    for candidate in candidates {
+        if candidate.state == nfa.accept {
+            outputs.insert(arena.materialize(candidate.path));
+            if outputs.len() > 1 {
+                return Err(MatchError::Ambiguous);
+            }
+        }
+    }
+
+    outputs.into_iter().next().ok_or(MatchError::NoMatch)
+}
+
+fn epsilon_closure(
+    nfa: &Nfa,
+    seeds: impl IntoIterator<Item = Candidate>,
+) -> Vec<Candidate> {
+    let mut queue = seeds.into_iter().collect::<VecDeque<_>>();
+    let mut seen = HashSet::new();
+    let mut out = Vec::new();
+
+    while let Some(candidate) = queue.pop_front() {
+        if !seen.insert(candidate) {
+            continue;
+        }
+        out.push(candidate);
+        for edge in &nfa.states[candidate.state].edges {
+            if let Edge::Epsilon(target) = edge {
+                queue.push_back(Candidate {
+                    state: *target,
+                    path: candidate.path,
+                });
+            }
+        }
+    }
+    out
+}
+
+fn matches(matcher: &Matcher, input: &InputToken) -> Option<Capture> {
+    match (matcher, input) {
+        (
+            Matcher::Command { literal, key },
+            InputToken::Word(value),
+        ) if literal == value => Some(Capture::Command(key.clone())),
+        (Matcher::Positional { key }, InputToken::Word(value)) => Some(Capture::Positional {
+            key: key.clone(),
+            value: value.clone(),
+        }),
+        (
+            Matcher::Option(expected),
+            InputToken::Option { id, value },
+        ) if expected == id => Some(Capture::Option {
+            id: *id,
+            value: value.clone(),
+        }),
+        (Matcher::AnyOption(allowed), InputToken::Option { id, value })
+            if allowed.get(*id).copied().unwrap_or(false) =>
+        {
+            Some(Capture::Option {
+                id: *id,
+                value: value.clone(),
+            })
+        }
+        _ => None,
+    }
+}
+
+#[derive(Default)]
+struct Builder {
+    states: Vec<State>,
+}
+
+impl Builder {
+    fn state(&mut self) -> usize {
+        let id = self.states.len();
+        self.states.push(State::default());
+        id
+    }
+
+    fn epsilon(&mut self, from: usize, to: usize) {
+        self.states[from].edges.push(Edge::Epsilon(to));
+    }
+
+    fn consume(&mut self, from: usize, matcher: Matcher, to: usize) {
+        self.states[from]
+            .edges
+            .push(Edge::Consume { matcher, target: to });
+    }
+
+    fn compile_expr(&mut self, expr: &Expr, allowed_options: &[bool]) -> (usize, usize) {
+        match expr {
+            Expr::Empty => {
+                let start = self.state();
+                let end = self.state();
+                self.epsilon(start, end);
+                (start, end)
+            }
+            Expr::Atom(atom) => {
+                let start = self.state();
+                let end = self.state();
+                let matcher = match atom {
+                    Atom::Command { literal, key } => Matcher::Command {
+                        literal: literal.clone(),
+                        key: key.clone(),
+                    },
+                    Atom::Positional { key } => Matcher::Positional { key: key.clone() },
+                    Atom::Option(id) => Matcher::Option(*id),
+                };
+                self.consume(start, matcher, end);
+                (start, end)
+            }
+            Expr::Sequence(items) => {
+                if items.is_empty() {
+                    return self.compile_expr(&Expr::Empty, allowed_options);
+                }
+                let (start, mut end) = self.compile_expr(&items[0], allowed_options);
+                for item in &items[1..] {
+                    let (next_start, next_end) = self.compile_expr(item, allowed_options);
+                    self.epsilon(end, next_start);
+                    end = next_end;
+                }
+                (start, end)
+            }
+            Expr::Alternative(branches) => {
+                let start = self.state();
+                let end = self.state();
+                for branch in branches {
+                    let (branch_start, branch_end) = self.compile_expr(branch, allowed_options);
+                    self.epsilon(start, branch_start);
+                    self.epsilon(branch_end, end);
+                }
+                (start, end)
+            }
+            Expr::Optional(inner) => {
+                let start = self.state();
+                let end = self.state();
+                let (inner_start, inner_end) = self.compile_expr(inner, allowed_options);
+                self.epsilon(start, end);
+                self.epsilon(start, inner_start);
+                self.epsilon(inner_end, end);
+                (start, end)
+            }
+            Expr::Repeat(inner) => {
+                let start = self.state();
+                let end = self.state();
+                let (inner_start, inner_end) = self.compile_expr(inner, allowed_options);
+                self.epsilon(start, inner_start);
+                self.epsilon(inner_end, inner_start);
+                self.epsilon(inner_end, end);
+                (start, end)
+            }
+            Expr::OptionsShortcut => {
+                let start = self.state();
+                let end = self.state();
+                self.epsilon(start, end);
+                self.consume(start, Matcher::AnyOption(allowed_options.to_vec()), start);
+                (start, end)
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn repeat_is_a_cycle_not_expansion() {
+        let pattern = Expr::Repeat(Box::new(Expr::Atom(Atom::Positional {
+            key: "file".into(),
+        })));
+        let nfa = compile(&[pattern], &OptionRegistry::default());
+        let input = (0..10_000)
+            .map(|i| InputToken::Word(i.to_string()))
+            .collect::<Vec<_>>();
+        let captures = execute(&nfa, &input).unwrap();
+        assert_eq!(captures.len(), 10_000);
+        assert!(nfa.states.len() < 10);
+    }
+
+    #[test]
+    fn detects_ambiguous_bindings() {
+        let patterns = vec![
+            Expr::Atom(Atom::Positional { key: "left".into() }),
+            Expr::Atom(Atom::Positional { key: "right".into() }),
+        ];
+        let nfa = compile(&patterns, &OptionRegistry::default());
+        assert_eq!(
+            execute(&nfa, &[InputToken::Word("x".into())]),
+            Err(MatchError::Ambiguous)
+        );
+    }
+}

--- a/rash_core/src/script_cli/matcher.rs
+++ b/rash_core/src/script_cli/matcher.rs
@@ -1,8 +1,8 @@
 use std::collections::{HashMap, HashSet, VecDeque};
 
+use super::InputToken;
 use super::grammar::{self, Atom, Expr};
 use super::options::OptionRegistry;
-use super::InputToken;
 
 #[derive(Clone, Debug, Hash, PartialEq, Eq)]
 pub(super) enum Capture {
@@ -168,10 +168,7 @@ pub(super) fn execute(nfa: &Nfa, input: &[InputToken]) -> Result<Vec<Capture>, M
     outputs.into_iter().next().ok_or(MatchError::NoMatch)
 }
 
-fn epsilon_closure(
-    nfa: &Nfa,
-    seeds: impl IntoIterator<Item = Candidate>,
-) -> Vec<Candidate> {
+fn epsilon_closure(nfa: &Nfa, seeds: impl IntoIterator<Item = Candidate>) -> Vec<Candidate> {
     let mut queue = seeds.into_iter().collect::<VecDeque<_>>();
     let mut seen = HashSet::new();
     let mut out = Vec::new();
@@ -237,9 +234,10 @@ impl Builder {
     }
 
     fn consume(&mut self, from: usize, matcher: Matcher, to: usize) {
-        self.states[from]
-            .edges
-            .push(Edge::Consume { matcher, target: to });
+        self.states[from].edges.push(Edge::Consume {
+            matcher,
+            target: to,
+        });
     }
 
     fn option_loop(&mut self, mask: Vec<bool>) -> (usize, usize) {
@@ -349,7 +347,9 @@ mod tests {
     fn detects_ambiguous_bindings() {
         let patterns = vec![
             Expr::Atom(Atom::Positional { key: "left".into() }),
-            Expr::Atom(Atom::Positional { key: "right".into() }),
+            Expr::Atom(Atom::Positional {
+                key: "right".into(),
+            }),
         ];
         let nfa = compile(&patterns, &OptionRegistry::default());
         assert_eq!(

--- a/rash_core/src/script_cli/matcher.rs
+++ b/rash_core/src/script_cli/matcher.rs
@@ -195,21 +195,19 @@ fn epsilon_closure(
 
 fn matches(matcher: &Matcher, input: &InputToken) -> Option<Capture> {
     match (matcher, input) {
-        (
-            Matcher::Command { literal, key },
-            InputToken::Word(value),
-        ) if literal == value => Some(Capture::Command(key.clone())),
+        (Matcher::Command { literal, key }, InputToken::Word(value)) if literal == value => {
+            Some(Capture::Command(key.clone()))
+        }
         (Matcher::Positional { key }, InputToken::Word(value)) => Some(Capture::Positional {
             key: key.clone(),
             value: value.clone(),
         }),
-        (
-            Matcher::Option(expected),
-            InputToken::Option { id, value },
-        ) if expected == id => Some(Capture::Option {
-            id: *id,
-            value: value.clone(),
-        }),
+        (Matcher::Option(expected), InputToken::Option { id, value }) if expected == id => {
+            Some(Capture::Option {
+                id: *id,
+                value: value.clone(),
+            })
+        }
         (Matcher::AnyOption(allowed), InputToken::Option { id, value })
             if allowed.get(*id).copied().unwrap_or(false) =>
         {
@@ -242,6 +240,14 @@ impl Builder {
         self.states[from]
             .edges
             .push(Edge::Consume { matcher, target: to });
+    }
+
+    fn option_loop(&mut self, mask: Vec<bool>) -> (usize, usize) {
+        let start = self.state();
+        let end = self.state();
+        self.epsilon(start, end);
+        self.consume(start, Matcher::AnyOption(mask), start);
+        (start, end)
     }
 
     fn compile_expr(&mut self, expr: &Expr, allowed_options: &[bool]) -> (usize, usize) {
@@ -297,6 +303,7 @@ impl Builder {
                 self.epsilon(inner_end, end);
                 (start, end)
             }
+            Expr::Required(inner) => self.compile_expr(inner, allowed_options),
             Expr::Repeat(inner) => {
                 let start = self.state();
                 let end = self.state();
@@ -306,13 +313,16 @@ impl Builder {
                 self.epsilon(inner_end, end);
                 (start, end)
             }
-            Expr::OptionsShortcut => {
-                let start = self.state();
-                let end = self.state();
-                self.epsilon(start, end);
-                self.consume(start, Matcher::AnyOption(allowed_options.to_vec()), start);
-                (start, end)
+            Expr::OptionsGroup(ids) => {
+                let mut mask = vec![false; allowed_options.len()];
+                for id in ids {
+                    if let Some(value) = mask.get_mut(*id) {
+                        *value = true;
+                    }
+                }
+                self.option_loop(mask)
             }
+            Expr::OptionsShortcut => self.option_loop(allowed_options.to_vec()),
         }
     }
 }
@@ -346,5 +356,19 @@ mod tests {
             execute(&nfa, &[InputToken::Word("x".into())]),
             Err(MatchError::Ambiguous)
         );
+    }
+
+    #[test]
+    fn option_group_accepts_any_declared_order() {
+        let pattern = Expr::OptionsGroup(vec![0, 1]);
+        let mut registry = OptionRegistry::from_doc(
+            "Usage: tool [-a] [-b]\n\n-a  a\n-b  b",
+            &["tool [-a] [-b]".to_owned()],
+        )
+        .unwrap();
+        registry.set_repeatable(&HashSet::new()).unwrap();
+        let nfa = compile(&[pattern], &registry);
+        let input = registry.normalize_args(&["-b", "-a"]).unwrap();
+        assert!(execute(&nfa, &input).is_ok());
     }
 }

--- a/rash_core/src/script_cli/matcher.rs
+++ b/rash_core/src/script_cli/matcher.rs
@@ -41,6 +41,7 @@ pub(super) struct Nfa {
     states: Vec<State>,
     start: usize,
     accept: usize,
+    help_option: Option<usize>,
 }
 
 #[derive(Clone, Copy, Debug, Hash, PartialEq, Eq)]
@@ -99,6 +100,7 @@ pub(super) fn compile(patterns: &[Expr], options: &OptionRegistry) -> Nfa {
     let mut builder = Builder::default();
     let start = builder.state();
     let accept = builder.state();
+    let help_option = options.all_ids().find(|id| options.is_help(*id));
 
     for pattern in patterns {
         let explicit = grammar::explicit_options(pattern);
@@ -118,6 +120,7 @@ pub(super) fn compile(patterns: &[Expr], options: &OptionRegistry) -> Nfa {
         states: builder.states,
         start,
         accept,
+        help_option,
     }
 }
 
@@ -138,7 +141,7 @@ pub(super) fn execute(nfa: &Nfa, input: &[InputToken]) -> Result<Vec<Capture>, M
                 let Edge::Consume { matcher, target } = edge else {
                     continue;
                 };
-                if let Some(capture) = matches(matcher, token) {
+                if let Some(capture) = matches(matcher, token, nfa.help_option) {
                     let path = Some(arena.append(candidate.path, capture));
                     next.push(Candidate {
                         state: *target,
@@ -190,7 +193,7 @@ fn epsilon_closure(nfa: &Nfa, seeds: impl IntoIterator<Item = Candidate>) -> Vec
     out
 }
 
-fn matches(matcher: &Matcher, input: &InputToken) -> Option<Capture> {
+fn matches(matcher: &Matcher, input: &InputToken, help_option: Option<usize>) -> Option<Capture> {
     match (matcher, input) {
         (Matcher::Command { literal, key }, InputToken::Word(value)) if literal == value => {
             Some(Capture::Command(key.clone()))
@@ -199,6 +202,14 @@ fn matches(matcher: &Matcher, input: &InputToken) -> Option<Capture> {
             key: key.clone(),
             value: value.clone(),
         }),
+        (Matcher::Positional { .. }, InputToken::Option { id, value })
+            if Some(*id) == help_option && value.is_none() =>
+        {
+            Some(Capture::Option {
+                id: *id,
+                value: None,
+            })
+        }
         (Matcher::Option(expected), InputToken::Option { id, value }) if expected == id => {
             Some(Capture::Option {
                 id: *id,
@@ -370,5 +381,23 @@ mod tests {
         let nfa = compile(&[pattern], &registry);
         let input = registry.normalize_args(&["-b", "-a"]).unwrap();
         assert!(execute(&nfa, &input).is_ok());
+    }
+
+    #[test]
+    fn help_option_can_be_consumed_by_positional_matcher() {
+        let pattern = Expr::Atom(Atom::Positional {
+            key: "target".into(),
+        });
+        let registry = OptionRegistry::from_doc(
+            "Usage: tool <target>\n\n-h --help  help",
+            &["tool <target>".to_owned()],
+        )
+        .unwrap();
+        let nfa = compile(&[pattern], &registry);
+        let input = registry.normalize_args(&["--help"]).unwrap();
+        assert!(matches!(
+            execute(&nfa, &input),
+            Ok(captures) if matches!(captures.as_slice(), [Capture::Option { .. }])
+        ));
     }
 }

--- a/rash_core/src/script_cli/matcher.rs
+++ b/rash_core/src/script_cli/matcher.rs
@@ -127,37 +127,8 @@ pub(super) fn compile(patterns: &[Expr], options: &OptionRegistry) -> Nfa {
 fn positional_help_options(options: &OptionRegistry) -> Vec<bool> {
     let mut mask = vec![false; options.len()];
     for id in options.all_ids() {
-        if options.is_help(id) {
-            mask[id] = true;
-        }
+        mask[id] = options.is_positional_help(id);
     }
-
-    let short_h = options.normalize_args(&["-h"]).ok().and_then(|tokens| {
-        let [InputToken::Option { id, value }] = tokens.as_slice() else {
-            return None;
-        };
-        value.is_none().then_some(*id)
-    });
-
-    if let Some(id) = short_h
-        && !options.is_help(id)
-    {
-        let long_h_same = options
-            .normalize_args(&["--h"])
-            .ok()
-            .and_then(|tokens| {
-                let [InputToken::Option { id, value }] = tokens.as_slice() else {
-                    return None;
-                };
-                value.is_none().then_some(*id)
-            })
-            .is_some_and(|long_id| long_id == id);
-
-        if !long_h_same {
-            mask[id] = true;
-        }
-    }
-
     mask
 }
 
@@ -419,6 +390,22 @@ mod tests {
     }
 
     #[test]
+    fn nullable_repeat_terminates_and_accepts_zero_or_more_values() {
+        let pattern = Expr::Repeat(Box::new(Expr::Optional(Box::new(Expr::Atom(
+            Atom::Positional { key: "file".into() },
+        )))));
+        let nfa = compile(&[pattern], &OptionRegistry::default());
+        assert!(execute(&nfa, &[]).is_ok());
+        let input = [
+            InputToken::Word("a".into()),
+            InputToken::Word("b".into()),
+        ];
+        let captures = execute(&nfa, &input).unwrap();
+        assert_eq!(captures.len(), 2);
+        assert!(nfa.states.len() < 10);
+    }
+
+    #[test]
     fn detects_ambiguous_bindings() {
         let patterns = vec![
             Expr::Atom(Atom::Positional { key: "left".into() }),
@@ -505,9 +492,21 @@ mod tests {
         .unwrap();
         let nfa = compile(&[pattern], &registry);
         let input = registry.normalize_args(&["-h"]).unwrap();
-        assert!(matches!(
-            execute(&nfa, &input),
-            Ok(captures) if matches!(captures.as_slice(), [Capture::Option { .. }])
-        ));
+        assert!(execute(&nfa, &input).is_ok());
+    }
+
+    #[test]
+    fn h_with_non_help_long_alias_cannot_fill_positional() {
+        let pattern = Expr::Atom(Atom::Positional {
+            key: "target".into(),
+        });
+        let registry = OptionRegistry::from_doc(
+            "Usage: tool <target>\n\n-h --host  host",
+            &["tool <target>".to_owned()],
+        )
+        .unwrap();
+        let nfa = compile(&[pattern], &registry);
+        let input = registry.normalize_args(&["-h"]).unwrap();
+        assert_eq!(execute(&nfa, &input), Err(MatchError::NoMatch));
     }
 }

--- a/rash_core/src/script_cli/matcher.rs
+++ b/rash_core/src/script_cli/matcher.rs
@@ -251,12 +251,35 @@ impl Builder {
         });
     }
 
+    fn optional_option(&mut self, id: usize) -> (usize, usize) {
+        let start = self.state();
+        let end = self.state();
+        self.epsilon(start, end);
+        self.consume(start, Matcher::Option(id), end);
+        (start, end)
+    }
+
     fn option_loop(&mut self, mask: Vec<bool>) -> (usize, usize) {
         let start = self.state();
         let end = self.state();
         self.epsilon(start, end);
         self.consume(start, Matcher::AnyOption(mask), start);
         (start, end)
+    }
+
+    fn options_shortcut(&mut self, allowed_options: &[bool]) -> (usize, usize) {
+        let mut ids = allowed_options
+            .iter()
+            .enumerate()
+            .filter_map(|(id, allowed)| allowed.then_some(id));
+        let first = ids.next();
+        let second = ids.next();
+
+        match (first, second) {
+            (None, _) => self.compile_expr(&Expr::Empty, allowed_options),
+            (Some(id), None) => self.optional_option(id),
+            (Some(_), Some(_)) => self.option_loop(allowed_options.to_vec()),
+        }
     }
 
     fn compile_expr(&mut self, expr: &Expr, allowed_options: &[bool]) -> (usize, usize) {
@@ -331,7 +354,7 @@ impl Builder {
                 }
                 self.option_loop(mask)
             }
-            Expr::OptionsShortcut => self.option_loop(allowed_options.to_vec()),
+            Expr::OptionsShortcut => self.options_shortcut(allowed_options),
         }
     }
 }
@@ -381,6 +404,34 @@ mod tests {
         let nfa = compile(&[pattern], &registry);
         let input = registry.normalize_args(&["-b", "-a"]).unwrap();
         assert!(execute(&nfa, &input).is_ok());
+    }
+
+    #[test]
+    fn options_shortcut_with_one_available_option_is_not_repeatable() {
+        let pattern = Expr::OptionsShortcut;
+        let registry = OptionRegistry::from_doc(
+            "Usage: tool [options]\n\n-a  a",
+            &["tool [options]".to_owned()],
+        )
+        .unwrap();
+        let nfa = compile(&[pattern], &registry);
+        let once = registry.normalize_args(&["-a"]).unwrap();
+        let twice = registry.normalize_args(&["-a", "-a"]).unwrap();
+        assert!(execute(&nfa, &once).is_ok());
+        assert_eq!(execute(&nfa, &twice), Err(MatchError::NoMatch));
+    }
+
+    #[test]
+    fn options_shortcut_with_multiple_available_options_keeps_legacy_loop() {
+        let pattern = Expr::OptionsShortcut;
+        let registry = OptionRegistry::from_doc(
+            "Usage: tool [options]\n\n-a  a\n-b  b",
+            &["tool [options]".to_owned()],
+        )
+        .unwrap();
+        let nfa = compile(&[pattern], &registry);
+        let repeated = registry.normalize_args(&["-a", "-a"]).unwrap();
+        assert!(execute(&nfa, &repeated).is_ok());
     }
 
     #[test]

--- a/rash_core/src/script_cli/mod.rs
+++ b/rash_core/src/script_cli/mod.rs
@@ -50,6 +50,12 @@ pub fn parse(file: &str, args: &[&str]) -> Result<Value> {
     options.set_repeatable(&metadata.repeatable_options)?;
 
     let normalized_args = options.normalize_args(args)?;
+    if normalized_args.iter().any(|token| {
+        matches!(token, InputToken::Option { id, .. } if options.is_help(*id))
+    }) {
+        return Err(Error::new(ErrorKind::GracefulExit, help_msg));
+    }
+
     let nfa = matcher::compile(&patterns, &options);
     let captures = match matcher::execute(&nfa, &normalized_args) {
         Ok(captures) => captures,

--- a/rash_core/src/script_cli/mod.rs
+++ b/rash_core/src/script_cli/mod.rs
@@ -50,9 +50,10 @@ pub fn parse(file: &str, args: &[&str]) -> Result<Value> {
     options.set_repeatable(&metadata.repeatable_options)?;
 
     let normalized_args = options.normalize_args(args)?;
-    if normalized_args.iter().any(|token| {
-        matches!(token, InputToken::Option { id, .. } if options.is_help(*id))
-    }) {
+    if normalized_args
+        .iter()
+        .any(|token| matches!(token, InputToken::Option { id, .. } if options.is_help(*id)))
+    {
         return Err(Error::new(ErrorKind::GracefulExit, help_msg));
     }
 

--- a/rash_core/src/script_cli/mod.rs
+++ b/rash_core/src/script_cli/mod.rs
@@ -2,6 +2,7 @@ mod grammar;
 mod matcher;
 mod options;
 
+use regex::Regex;
 use serde_json::{Map, Value};
 
 use crate::error::{Error, ErrorKind, Result};
@@ -167,14 +168,12 @@ fn value_enabled(value: Option<&Value>) -> bool {
 }
 
 fn parse_help(file: &str) -> String {
+    let re = Regex::new(r"#(.*)").unwrap();
     file.split('\n')
         .skip(1)
-        .map_while(|line| {
-            line.find('#')
-                .map(|position| line[position + 1..].to_owned())
-        })
-        .filter(|line| !line.starts_with('!'))
-        .map(|line| line.strip_prefix(' ').unwrap_or(&line).to_owned())
+        .map_while(|line| re.captures(line))
+        .filter(|cap| !cap[1].starts_with('!'))
+        .map(|cap| cap[1].to_owned().replacen(' ', "", 1))
         .chain([
             "Note: Options must be preceded by `--`. If not, you are passing options directly to rash."
                 .to_owned(),
@@ -185,36 +184,27 @@ fn parse_help(file: &str) -> String {
         .join("\n")
 }
 
+fn parse_usage_multiline(doc: &str) -> Option<Vec<String>> {
+    let re = Regex::new(r"(?mi)Usage:\n((.|\n)*?(^[a-z\n]|\z))").unwrap();
+    let re_rm_indentation = Regex::new(r"\s+(.*)").unwrap();
+    let cap = re.captures_iter(doc).next()?;
+    Some(
+        cap[1]
+            .split('\n')
+            .map_while(|line| re_rm_indentation.captures(line))
+            .map(|cap| cap[1].to_owned())
+            .collect::<Vec<_>>(),
+    )
+}
+
+fn parse_usage_one_line(doc: &str) -> Option<Vec<String>> {
+    let re = Regex::new(r"(?i)Usage:\s+(.*)\n").unwrap();
+    let cap = re.captures_iter(doc).next()?;
+    Some(vec![cap[1].to_owned()])
+}
+
 fn parse_usage(doc: &str) -> Option<Vec<String>> {
-    let lines = doc.lines().collect::<Vec<_>>();
-    for (index, line) in lines.iter().enumerate() {
-        let trimmed = line.trim_start();
-        if !trimmed
-            .get(..6)
-            .is_some_and(|prefix| prefix.eq_ignore_ascii_case("usage:"))
-        {
-            continue;
-        }
-
-        let first = trimmed[6..].trim();
-        if !first.is_empty() {
-            return Some(vec![first.to_owned()]);
-        }
-
-        let mut usages = Vec::new();
-        for next in lines.iter().skip(index + 1) {
-            if next.trim().is_empty() {
-                break;
-            }
-            if next.chars().next().is_some_and(char::is_whitespace) {
-                usages.push(next.trim().to_owned());
-            } else {
-                break;
-            }
-        }
-        return (!usages.is_empty()).then_some(usages);
-    }
-    None
+    parse_usage_multiline(doc).or_else(|| parse_usage_one_line(doc))
 }
 
 #[cfg(test)]

--- a/rash_core/src/script_cli/mod.rs
+++ b/rash_core/src/script_cli/mod.rs
@@ -50,13 +50,6 @@ pub fn parse(file: &str, args: &[&str]) -> Result<Value> {
     options.set_repeatable(&metadata.repeatable_options)?;
 
     let normalized_args = options.normalize_args(args)?;
-    if normalized_args
-        .iter()
-        .any(|token| matches!(token, InputToken::Option { id, .. } if options.is_help(*id)))
-    {
-        return Err(Error::new(ErrorKind::GracefulExit, help_msg));
-    }
-
     let nfa = matcher::compile(&patterns, &options);
     let captures = match matcher::execute(&nfa, &normalized_args) {
         Ok(captures) => captures,

--- a/rash_core/src/script_cli/mod.rs
+++ b/rash_core/src/script_cli/mod.rs
@@ -80,7 +80,10 @@ fn build_vars(
     let mut root = Map::new();
 
     if !options.is_empty() {
-        root.insert("options".to_owned(), Value::Object(options.initial_options()));
+        root.insert(
+            "options".to_owned(),
+            Value::Object(options.initial_options()),
+        );
     }
 
     for (command, repeated) in &metadata.command_repeated {
@@ -97,7 +100,12 @@ fn build_vars(
     for capture in captures {
         match capture {
             Capture::Command(key) => {
-                if metadata.command_repeated.get(&key).copied().unwrap_or(false) {
+                if metadata
+                    .command_repeated
+                    .get(&key)
+                    .copied()
+                    .unwrap_or(false)
+                {
                     let count = root.get(&key).and_then(Value::as_u64).unwrap_or_default() + 1;
                     root.insert(key, Value::from(count));
                 } else {
@@ -129,7 +137,10 @@ fn build_vars(
                     .get_mut("options")
                     .and_then(Value::as_object_mut)
                     .ok_or_else(|| {
-                        Error::new(ErrorKind::InvalidData, "Option capture without options context")
+                        Error::new(
+                            ErrorKind::InvalidData,
+                            "Option capture without options context",
+                        )
                     })?;
                 options.apply_capture(options_value, id, value.as_deref())?;
             }
@@ -178,7 +189,10 @@ fn parse_usage(doc: &str) -> Option<Vec<String>> {
     let lines = doc.lines().collect::<Vec<_>>();
     for (index, line) in lines.iter().enumerate() {
         let trimmed = line.trim_start();
-        if trimmed.len() < 6 || !trimmed[..6].eq_ignore_ascii_case("usage:") {
+        if !trimmed
+            .get(..6)
+            .is_some_and(|prefix| prefix.eq_ignore_ascii_case("usage:"))
+        {
             continue;
         }
 
@@ -192,7 +206,7 @@ fn parse_usage(doc: &str) -> Option<Vec<String>> {
             if next.trim().is_empty() {
                 break;
             }
-            if next.starts_with(char::is_whitespace) {
+            if next.chars().next().is_some_and(char::is_whitespace) {
                 usages.push(next.trim().to_owned());
             } else {
                 break;
@@ -213,7 +227,9 @@ mod tests {
         match (legacy, compiled) {
             (Ok(legacy), Ok(compiled)) => assert_eq!(compiled, legacy),
             (Err(legacy), Err(compiled)) => assert_eq!(compiled.kind(), legacy.kind()),
-            (legacy, compiled) => panic!("parser mismatch: legacy={legacy:?} compiled={compiled:?}"),
+            (legacy, compiled) => {
+                panic!("parser mismatch: legacy={legacy:?} compiled={compiled:?}")
+            }
         }
     }
 
@@ -372,7 +388,9 @@ mod tests {
 # Usage: tool <file>...
 #
 "#;
-        let owned = (0..10_000).map(|value| value.to_string()).collect::<Vec<_>>();
+        let owned = (0..10_000)
+            .map(|value| value.to_string())
+            .collect::<Vec<_>>();
         let args = owned.iter().map(String::as_str).collect::<Vec<_>>();
         let result = parse(file, &args).unwrap();
         assert_eq!(result["file"].as_array().unwrap().len(), 10_000);

--- a/rash_core/src/script_cli/mod.rs
+++ b/rash_core/src/script_cli/mod.rs
@@ -1,0 +1,380 @@
+mod grammar;
+mod matcher;
+mod options;
+
+use serde_json::{Map, Value};
+
+use crate::error::{Error, ErrorKind, Result};
+
+use grammar::Metadata;
+use matcher::{Capture, MatchError};
+use options::OptionRegistry;
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(super) enum Token {
+    LeftBracket,
+    RightBracket,
+    LeftParen,
+    RightParen,
+    Pipe,
+    Ellipsis,
+    Atom(String),
+    Option(usize),
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(super) enum InputToken {
+    Word(String),
+    Option { id: usize, value: Option<String> },
+}
+
+/// Parse the CLI declaration embedded in a Rash script and return template variables.
+///
+/// The syntax is Docopt-inspired, but the implementation is Rash-specific. Usage patterns are
+/// parsed into an AST, compiled into an epsilon-NFA, and matched directly against normalized argv.
+/// No concrete usage combinations are generated.
+pub fn parse(file: &str, args: &[&str]) -> Result<Value> {
+    let help_msg = parse_help(file);
+    let usages = match parse_usage(&help_msg) {
+        Some(usages) => usages,
+        None => return Ok(json!({})),
+    };
+
+    let mut options = OptionRegistry::from_doc(&help_msg, &usages)?;
+    let patterns = usages
+        .iter()
+        .map(|usage| options.tokenize_usage(usage).and_then(grammar::parse))
+        .collect::<Result<Vec<_>>>()?;
+
+    let metadata = grammar::analyze(&patterns);
+    options.set_repeatable(&metadata.repeatable_options)?;
+
+    let normalized_args = options.normalize_args(args)?;
+    let nfa = matcher::compile(&patterns, &options);
+    let captures = match matcher::execute(&nfa, &normalized_args) {
+        Ok(captures) => captures,
+        Err(MatchError::NoMatch) => {
+            return Err(Error::new(ErrorKind::InvalidData, help_msg));
+        }
+        Err(MatchError::Ambiguous) => {
+            return Err(Error::new(
+                ErrorKind::InvalidData,
+                format!("Ambiguous usage declaration.\n\n{help_msg}"),
+            ));
+        }
+    };
+
+    let vars = build_vars(&metadata, &options, captures)?;
+    if help_requested(&vars) {
+        Err(Error::new(ErrorKind::GracefulExit, help_msg))
+    } else {
+        Ok(vars)
+    }
+}
+
+fn build_vars(
+    metadata: &Metadata,
+    options: &OptionRegistry,
+    captures: Vec<Capture>,
+) -> Result<Value> {
+    let mut root = Map::new();
+
+    if !options.is_empty() {
+        root.insert("options".to_owned(), Value::Object(options.initial_options()));
+    }
+
+    for (command, repeated) in &metadata.command_repeated {
+        root.insert(
+            command.clone(),
+            if *repeated {
+                Value::from(0_u64)
+            } else {
+                Value::Bool(false)
+            },
+        );
+    }
+
+    for capture in captures {
+        match capture {
+            Capture::Command(key) => {
+                if metadata.command_repeated.get(&key).copied().unwrap_or(false) {
+                    let count = root.get(&key).and_then(Value::as_u64).unwrap_or_default() + 1;
+                    root.insert(key, Value::from(count));
+                } else {
+                    root.insert(key, Value::Bool(true));
+                }
+            }
+            Capture::Positional { key, value } => {
+                if metadata
+                    .positional_repeated
+                    .get(&key)
+                    .copied()
+                    .unwrap_or(false)
+                {
+                    match root.entry(key).or_insert_with(|| Value::Array(Vec::new())) {
+                        Value::Array(values) => values.push(Value::String(value)),
+                        current => {
+                            return Err(Error::new(
+                                ErrorKind::InvalidData,
+                                format!("Positional argument changed type unexpectedly: {current}"),
+                            ));
+                        }
+                    }
+                } else {
+                    root.insert(key, Value::String(value));
+                }
+            }
+            Capture::Option { id, value } => {
+                let options_value = root
+                    .get_mut("options")
+                    .and_then(Value::as_object_mut)
+                    .ok_or_else(|| {
+                        Error::new(ErrorKind::InvalidData, "Option capture without options context")
+                    })?;
+                options.apply_capture(options_value, id, value.as_deref())?;
+            }
+        }
+    }
+
+    Ok(Value::Object(root))
+}
+
+fn help_requested(vars: &Value) -> bool {
+    value_enabled(vars.get("help"))
+        || vars
+            .get("options")
+            .and_then(|options| options.get("help"))
+            .is_some_and(|value| value_enabled(Some(value)))
+}
+
+fn value_enabled(value: Option<&Value>) -> bool {
+    match value {
+        Some(Value::Bool(value)) => *value,
+        Some(Value::Number(value)) => value.as_u64().is_some_and(|value| value > 0),
+        _ => false,
+    }
+}
+
+fn parse_help(file: &str) -> String {
+    file.split('\n')
+        .skip(1)
+        .map_while(|line| {
+            line.find('#')
+                .map(|position| line[position + 1..].to_owned())
+        })
+        .filter(|line| !line.starts_with('!'))
+        .map(|line| line.strip_prefix(' ').unwrap_or(&line).to_owned())
+        .chain([
+            "Note: Options must be preceded by `--`. If not, you are passing options directly to rash."
+                .to_owned(),
+            "For more information check rash options with `rash --help`.".to_owned(),
+            String::new(),
+        ])
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+fn parse_usage(doc: &str) -> Option<Vec<String>> {
+    let lines = doc.lines().collect::<Vec<_>>();
+    for (index, line) in lines.iter().enumerate() {
+        let trimmed = line.trim_start();
+        if trimmed.len() < 6 || !trimmed[..6].eq_ignore_ascii_case("usage:") {
+            continue;
+        }
+
+        let first = trimmed[6..].trim();
+        if !first.is_empty() {
+            return Some(vec![first.to_owned()]);
+        }
+
+        let mut usages = Vec::new();
+        for next in lines.iter().skip(index + 1) {
+            if next.trim().is_empty() {
+                break;
+            }
+            if next.starts_with(char::is_whitespace) {
+                usages.push(next.trim().to_owned());
+            } else {
+                break;
+            }
+        }
+        return (!usages.is_empty()).then_some(usages);
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn assert_parity(file: &str, args: &[&str]) {
+        let legacy = crate::docopt::parse(file, args);
+        let compiled = parse(file, args);
+        match (legacy, compiled) {
+            (Ok(legacy), Ok(compiled)) => assert_eq!(compiled, legacy),
+            (Err(legacy), Err(compiled)) => assert_eq!(compiled.kind(), legacy.kind()),
+            (legacy, compiled) => panic!("parser mismatch: legacy={legacy:?} compiled={compiled:?}"),
+        }
+    }
+
+    #[test]
+    fn parity_dotfiles_cli() {
+        let file = r#"
+#!/usr/bin/env rash
+#
+# Usage:
+#   ./dots (install|update|help) <package_filters>...
+#
+"#;
+        assert_parity(file, &["install", "foo", "bar"]);
+        assert_parity(file, &["update", "foo"]);
+        assert_parity(file, &["help", "foo"]);
+    }
+
+    #[test]
+    fn parity_repeatable_group() {
+        let file = r#"
+#!/usr/bin/env rash
+#
+# Usage:
+#   foo (<a> <b>)...
+#
+"#;
+        assert_parity(file, &["a", "b", "c", "d"]);
+        assert_parity(file, &["a", "b", "c"]);
+    }
+
+    #[test]
+    fn parity_options_aliases_defaults_and_clusters() {
+        let file = r#"
+#!/usr/bin/env rash
+#
+# Usage: my_program.rh [-hso FILE] [--quiet | --verbose] [INPUT ...]
+#
+# -h --help    show this
+# -s --sorted  sorted output
+# -o FILE      specify output file [default: ./test.txt]
+# --quiet      print less text
+# --verbose    print more text
+# --dry-run    run without modifications
+#
+"#;
+        assert_parity(file, &["-o", "yea", "--sorted"]);
+        assert_parity(file, &["-h"]);
+    }
+
+    #[test]
+    fn parity_repeatable_flag() {
+        let file = r#"
+#!/usr/bin/env rash
+#
+# Usage: foo [-d]...
+#
+"#;
+        assert_parity(file, &[]);
+        assert_parity(file, &["-d"]);
+        assert_parity(file, &["-dd"]);
+        assert_parity(file, &["-d", "-d"]);
+    }
+
+    #[test]
+    fn parity_complex_docopt_example() {
+        let file = r#"
+#!/usr/bin/env rash
+#
+# Usage:
+#   naval_fate.rh ship new <name>...
+#   naval_fate.rh ship <name> move <x> <y> [--speed=<kn>]
+#   naval_fate.rh ship shoot <x> <y>
+#   naval_fate.rh mine (set|remove) <x> <y> [--moored|--drifting]
+#   naval_fate.rh -h | --help
+#   naval_fate.rh --version
+#
+# Options:
+#   -h --help        Show this screen.
+#   -v --version     Show version.
+#   -s --speed=<kn>  Speed in knots [default: 10].
+#   --moored         Moored (anchored) mine.
+#   --drifting       Drifting mine.
+"#;
+        assert_parity(file, &["mine", "set", "10", "50", "--drifting"]);
+        assert_parity(file, &["ship", "foo", "move", "2", "3", "-s20"]);
+        assert_parity(file, &["ship", "new", "a", "b", "c"]);
+    }
+
+    #[test]
+    fn parity_options_shortcut_matrix() {
+        let file = r#"
+#!/usr/bin/env rash
+#
+# Usage: tool [options] <target>
+#
+# Options:
+#   -a --alpha  alpha
+#   -b --beta   beta
+#   -c --gamma  gamma
+#
+"#;
+        for mask in 0..8 {
+            let mut args = Vec::new();
+            if mask & 1 != 0 {
+                args.push("--alpha");
+            }
+            if mask & 2 != 0 {
+                args.push("--beta");
+            }
+            if mask & 4 != 0 {
+                args.push("--gamma");
+            }
+            args.push("target");
+            assert_parity(file, &args);
+        }
+    }
+
+    #[test]
+    fn options_shortcut_is_scoped_per_usage_pattern() {
+        let file = r#"
+#!/usr/bin/env rash
+#
+# Usage:
+#   tool get [options]
+#   tool set [--force]
+#
+# Options:
+#   --force    force
+#   --verbose  verbose
+#
+"#;
+        let result = parse(file, &["get", "--force"]).unwrap();
+        assert_eq!(result["options"]["force"], true);
+    }
+
+    #[test]
+    fn ambiguous_usage_is_rejected_deterministically() {
+        let file = r#"
+#!/usr/bin/env rash
+#
+# Usage:
+#   tool <source> <dest>
+#   tool <input> <output>
+#
+"#;
+        let error = parse(file, &["a", "b"]).unwrap_err();
+        assert_eq!(error.kind(), ErrorKind::InvalidData);
+        assert!(error.to_string().contains("Ambiguous usage declaration"));
+    }
+
+    #[test]
+    fn ten_thousand_repeatable_arguments_do_not_expand_grammar() {
+        let file = r#"
+#!/usr/bin/env rash
+#
+# Usage: tool <file>...
+#
+"#;
+        let owned = (0..10_000).map(|value| value.to_string()).collect::<Vec<_>>();
+        let args = owned.iter().map(String::as_str).collect::<Vec<_>>();
+        let result = parse(file, &args).unwrap();
+        assert_eq!(result["file"].as_array().unwrap().len(), 10_000);
+    }
+}

--- a/rash_core/src/script_cli/options.rs
+++ b/rash_core/src/script_cli/options.rs
@@ -9,7 +9,7 @@ use crate::error::{Error, ErrorKind, Result};
 use super::{InputToken, Token};
 
 static RE_DEFAULT_VALUE: LazyLock<Regex> =
-    LazyLock::new(|| Regex::new(r"(?i)\[default:\s*(.*?)\]").unwrap());
+    LazyLock::new(|| Regex::new(r"\[default: (.*)\]").unwrap());
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 struct OptionSpec {
@@ -66,6 +66,10 @@ impl OptionRegistry {
 
     pub fn is_empty(&self) -> bool {
         self.specs.is_empty()
+    }
+
+    pub fn is_help(&self, id: usize) -> bool {
+        self.specs.get(id).is_some_and(|spec| spec.key() == "help")
     }
 
     pub fn set_repeatable(&mut self, ids: &HashSet<usize>) -> Result<()> {

--- a/rash_core/src/script_cli/options.rs
+++ b/rash_core/src/script_cli/options.rs
@@ -6,7 +6,6 @@ use serde_json::{Map, Value};
 
 use crate::error::{Error, ErrorKind, Result};
 
-use super::grammar::is_lower_word;
 use super::{InputToken, Token};
 
 static RE_DEFAULT_VALUE: LazyLock<Regex> =
@@ -352,18 +351,6 @@ impl OptionRegistry {
         for word in words {
             if word.starts_with("--") && word != "--" {
                 let (name, has_value) = split_option_declaration(&word);
-                let Some(identifier) = name.strip_prefix("--") else {
-                    return Err(Error::new(
-                        ErrorKind::InvalidData,
-                        format!("Invalid long option in usage: {name}"),
-                    ));
-                };
-                if !is_lower_word(identifier) {
-                    return Err(Error::new(
-                        ErrorKind::InvalidData,
-                        format!("Invalid long option in usage: {name}"),
-                    ));
-                }
                 self.upsert(OptionSpec {
                     short: None,
                     long: Some(name),
@@ -383,12 +370,6 @@ impl OptionRegistry {
         for (offset, ch) in body.char_indices() {
             if ch == '=' {
                 break;
-            }
-            if !ch.is_ascii_lowercase() {
-                return Err(Error::new(
-                    ErrorKind::InvalidData,
-                    format!("Invalid short option in usage: -{ch}"),
-                ));
             }
             let alias = format!("-{ch}");
             let next_offset = offset + ch.len_utf8();
@@ -632,14 +613,6 @@ mod tests {
         let registry = OptionRegistry::from_doc(help, &usages).unwrap();
         let tokens = registry.tokenize_usage(&usages[0]).unwrap();
         assert_eq!(tokens.iter().filter(|token| matches!(token, Token::Atom(_))).count(), 0);
-    }
-
-    #[test]
-    fn rejects_usage_option_identifiers_outside_legacy_grammar() {
-        for usage in ["tool [--Foo]", "tool [--foo2]", "tool [-X]"] {
-            let registry = OptionRegistry::from_doc(usage, &[usage.to_owned()]);
-            assert!(registry.is_err(), "usage={usage}");
-        }
     }
 
     #[test]

--- a/rash_core/src/script_cli/options.rs
+++ b/rash_core/src/script_cli/options.rs
@@ -74,10 +74,10 @@ impl OptionRegistry {
     }
 
     pub fn is_positional_help(&self, id: usize) -> bool {
-        self.specs.get(id).is_some_and(|spec| {
-            spec.long.as_deref() == Some("--help")
-                || (spec.long.is_none() && spec.short.as_deref() == Some("-h"))
-        })
+        self.is_help(id)
+            || self.specs.get(id).is_some_and(|spec| {
+                spec.long.is_none() && spec.short.as_deref() == Some("-h")
+            })
     }
 
     pub fn set_repeatable(&mut self, ids: &HashSet<usize>) -> Result<()> {

--- a/rash_core/src/script_cli/options.rs
+++ b/rash_core/src/script_cli/options.rs
@@ -72,6 +72,13 @@ impl OptionRegistry {
         self.specs.get(id).is_some_and(|spec| spec.key() == "help")
     }
 
+    pub fn is_positional_help(&self, id: usize) -> bool {
+        self.specs.get(id).is_some_and(|spec| {
+            spec.long.as_deref() == Some("--help")
+                || (spec.long.is_none() && spec.short.as_deref() == Some("-h"))
+        })
+    }
+
     pub fn set_repeatable(&mut self, ids: &HashSet<usize>) -> Result<()> {
         for id in ids {
             let Some(spec) = self.specs.get_mut(*id) else {
@@ -615,6 +622,21 @@ mod tests {
         let mut registry = OptionRegistry::from_doc(help, &usages).unwrap();
         registry.set_repeatable(&HashSet::from([0])).unwrap();
         assert_eq!(registry.initial_options()["tag"], Value::Null);
+    }
+
+    #[test]
+    fn positional_help_distinguishes_short_only_h_from_other_aliases() {
+        let short_only = OptionRegistry::from_doc("Usage: tool <value>\n\n-h  helpish", &["tool <value>".to_owned()]).unwrap();
+        assert!(short_only.is_positional_help(0));
+        assert!(!short_only.is_help(0));
+
+        let real_help = OptionRegistry::from_doc("Usage: tool <value>\n\n-h --help  help", &["tool <value>".to_owned()]).unwrap();
+        assert!(real_help.is_positional_help(0));
+        assert!(real_help.is_help(0));
+
+        let host = OptionRegistry::from_doc("Usage: tool <value>\n\n-h --host  host", &["tool <value>".to_owned()]).unwrap();
+        assert!(!host.is_positional_help(0));
+        assert!(!host.is_help(0));
     }
 
     #[test]

--- a/rash_core/src/script_cli/options.rs
+++ b/rash_core/src/script_cli/options.rs
@@ -183,8 +183,7 @@ impl OptionRegistry {
                 continue;
             }
 
-            if arg.starts_with('-') {
-                let body = &arg[1..];
+            if let Some(body) = arg.strip_prefix('-') {
                 if body.is_empty() {
                     out.push(InputToken::Word(arg.to_owned()));
                     i += 1;
@@ -495,21 +494,21 @@ impl OptionRegistry {
         }
 
         let id = self.specs.len();
-        if let Some(alias) = &incoming.short {
-            if self.aliases.insert(alias.clone(), id).is_some() {
-                return Err(Error::new(
-                    ErrorKind::InvalidData,
-                    format!("Duplicate option alias: {alias}"),
-                ));
-            }
+        if let Some(alias) = &incoming.short
+            && self.aliases.insert(alias.clone(), id).is_some()
+        {
+            return Err(Error::new(
+                ErrorKind::InvalidData,
+                format!("Duplicate option alias: {alias}"),
+            ));
         }
-        if let Some(alias) = &incoming.long {
-            if self.aliases.insert(alias.clone(), id).is_some() {
-                return Err(Error::new(
-                    ErrorKind::InvalidData,
-                    format!("Duplicate option alias: {alias}"),
-                ));
-            }
+        if let Some(alias) = &incoming.long
+            && self.aliases.insert(alias.clone(), id).is_some()
+        {
+            return Err(Error::new(
+                ErrorKind::InvalidData,
+                format!("Duplicate option alias: {alias}"),
+            ));
         }
         self.specs.push(incoming);
         Ok(id)

--- a/rash_core/src/script_cli/options.rs
+++ b/rash_core/src/script_cli/options.rs
@@ -109,15 +109,9 @@ impl OptionRegistry {
         while i < tokens.len() {
             match &tokens[i] {
                 Token::Atom(atom) if atom.starts_with('-') => {
-                    let (option_ids, consume_next) = self.expand_usage_option(atom)?;
+                    let (option_ids, takes_separate_value) = self.expand_usage_option(atom)?;
                     out.extend(option_ids.into_iter().map(Token::Option));
-                    if consume_next {
-                        let Some(Token::Atom(_)) = tokens.get(i + 1) else {
-                            return Err(Error::new(
-                                ErrorKind::InvalidData,
-                                format!("Option {atom} requires a value placeholder in usage"),
-                            ));
-                        };
+                    if takes_separate_value && is_usage_value_placeholder(tokens.get(i + 1)) {
                         i += 1;
                     }
                 }
@@ -415,7 +409,7 @@ impl OptionRegistry {
 
         let body = atom.strip_prefix('-').unwrap_or(atom);
         let mut ids = Vec::new();
-        let mut consume_next = false;
+        let mut takes_separate_value = false;
         for (offset, ch) in body.char_indices() {
             if ch == '=' {
                 break;
@@ -427,7 +421,7 @@ impl OptionRegistry {
             ids.push(id);
             if self.specs[id].takes_value {
                 let next_offset = offset + ch.len_utf8();
-                consume_next = body[next_offset..].is_empty();
+                takes_separate_value = body[next_offset..].is_empty();
                 break;
             }
         }
@@ -437,7 +431,7 @@ impl OptionRegistry {
                 format!("Invalid option in usage: {atom}"),
             ));
         }
-        Ok((ids, consume_next))
+        Ok((ids, takes_separate_value))
     }
 
     fn upsert(&mut self, incoming: OptionSpec) -> Result<usize> {
@@ -515,6 +509,25 @@ impl OptionRegistry {
     }
 }
 
+fn is_usage_value_placeholder(token: Option<&Token>) -> bool {
+    let Some(Token::Atom(value)) = token else {
+        return false;
+    };
+
+    if value.starts_with('<') && value.ends_with('>') {
+        return true;
+    }
+
+    let has_alpha = value.chars().any(char::is_alphabetic);
+    has_alpha
+        && value
+            .chars()
+            .all(|ch| !ch.is_alphabetic() || ch.is_uppercase())
+        && value
+            .chars()
+            .all(|ch| ch.is_alphanumeric() || matches!(ch, '_' | '-'))
+}
+
 fn split_option_declaration(value: &str) -> (String, bool) {
     match value.split_once('=') {
         Some((name, _)) => (name.to_owned(), true),
@@ -583,6 +596,23 @@ mod tests {
         let registry = OptionRegistry::from_doc(help, &usages).unwrap();
         let tokens = registry.tokenize_usage(&usages[0]).unwrap();
         assert!(matches!(tokens[1], Token::Option(_)));
+    }
+
+    #[test]
+    fn documented_value_option_does_not_require_usage_placeholder() {
+        let help = "Usage: tool [--type]\n\n--type=TYPE  resource type";
+        let usages = vec!["tool [--type]".to_owned()];
+        let registry = OptionRegistry::from_doc(help, &usages).unwrap();
+        assert!(registry.tokenize_usage(&usages[0]).is_ok());
+    }
+
+    #[test]
+    fn separate_usage_value_placeholder_is_not_a_positional() {
+        let help = "Usage: tool [-o FILE]\n\n-o FILE  output";
+        let usages = vec!["tool [-o FILE]".to_owned()];
+        let registry = OptionRegistry::from_doc(help, &usages).unwrap();
+        let tokens = registry.tokenize_usage(&usages[0]).unwrap();
+        assert_eq!(tokens.iter().filter(|token| matches!(token, Token::Atom(_))).count(), 0);
     }
 
     #[test]

--- a/rash_core/src/script_cli/options.rs
+++ b/rash_core/src/script_cli/options.rs
@@ -1,0 +1,611 @@
+use std::collections::{HashMap, HashSet};
+use std::sync::LazyLock;
+
+use regex::Regex;
+use serde_json::{Map, Value};
+
+use crate::error::{Error, ErrorKind, Result};
+
+use super::{InputToken, Token};
+
+static RE_DEFAULT_VALUE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"(?i)\[default:\s*(.*?)\]").unwrap());
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct OptionSpec {
+    short: Option<String>,
+    long: Option<String>,
+    takes_value: bool,
+    default_value: Option<String>,
+    repeatable: bool,
+}
+
+impl OptionSpec {
+    fn key(&self) -> String {
+        self.preferred_name()
+            .trim_start_matches('-')
+            .replace('-', "_")
+    }
+
+    fn preferred_name(&self) -> &str {
+        self.long
+            .as_deref()
+            .or(self.short.as_deref())
+            .expect("option must have at least one name")
+    }
+}
+
+#[derive(Clone, Debug, Default)]
+pub(super) struct OptionRegistry {
+    specs: Vec<OptionSpec>,
+    aliases: HashMap<String, usize>,
+}
+
+impl OptionRegistry {
+    pub fn from_doc(help: &str, usages: &[String]) -> Result<Self> {
+        let mut registry = Self::default();
+
+        for line in help.lines() {
+            let trimmed = line.trim_start();
+            if !trimmed.starts_with('-') {
+                continue;
+            }
+            registry.add_description_line(trimmed)?;
+        }
+
+        for usage in usages {
+            registry.discover_usage_options(usage)?;
+        }
+
+        Ok(registry)
+    }
+
+    pub fn len(&self) -> usize {
+        self.specs.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.specs.is_empty()
+    }
+
+    pub fn set_repeatable(&mut self, ids: &HashSet<usize>) -> Result<()> {
+        for id in ids {
+            let Some(spec) = self.specs.get_mut(*id) else {
+                return Err(Error::new(
+                    ErrorKind::InvalidData,
+                    format!("Unknown option id {id}"),
+                ));
+            };
+            if spec.takes_value {
+                return Err(Error::new(
+                    ErrorKind::InvalidData,
+                    format!(
+                        "Repeatable options with values are not supported: {}",
+                        spec.preferred_name()
+                    ),
+                ));
+            }
+            spec.repeatable = true;
+        }
+        Ok(())
+    }
+
+    pub fn tokenize_usage(&self, usage: &str) -> Result<Vec<Token>> {
+        let mut tokens = lex_usage(usage)?;
+        if !matches!(tokens.first(), Some(Token::Atom(_))) {
+            return Err(Error::new(
+                ErrorKind::InvalidData,
+                format!("Usage must start with a program name: {usage}"),
+            ));
+        }
+        tokens.remove(0);
+
+        let mut out = Vec::with_capacity(tokens.len());
+        let mut i = 0;
+        while i < tokens.len() {
+            match &tokens[i] {
+                Token::Atom(atom) if atom.starts_with('-') => {
+                    let (option_ids, consume_next) = self.expand_usage_option(atom)?;
+                    out.extend(option_ids.into_iter().map(Token::Option));
+                    if consume_next {
+                        let Some(Token::Atom(_)) = tokens.get(i + 1) else {
+                            return Err(Error::new(
+                                ErrorKind::InvalidData,
+                                format!("Option {atom} requires a value placeholder in usage"),
+                            ));
+                        };
+                        i += 1;
+                    }
+                }
+                token => out.push(token.clone()),
+            }
+            i += 1;
+        }
+        Ok(out)
+    }
+
+    pub fn normalize_args(&self, args: &[&str]) -> Result<Vec<InputToken>> {
+        let mut out = Vec::with_capacity(args.len());
+        let mut seen = HashMap::<usize, usize>::new();
+        let mut i = 0;
+
+        while i < args.len() {
+            let arg = args[i];
+            if arg == "-" {
+                out.push(InputToken::Word(arg.to_owned()));
+                i += 1;
+                continue;
+            }
+
+            if arg.starts_with("--") {
+                if arg == "--" {
+                    return Err(Error::new(ErrorKind::InvalidData, "Unknown option: --"));
+                }
+                let (name, attached) = match arg.split_once('=') {
+                    Some((name, value)) => (name, Some(value.to_owned())),
+                    None => (arg, None),
+                };
+                let id = self.find(name).ok_or_else(|| {
+                    Error::new(ErrorKind::InvalidData, format!("Unknown option: {name}"))
+                })?;
+                let spec = &self.specs[id];
+                let value = if spec.takes_value {
+                    match attached {
+                        Some(value) => Some(value),
+                        None => {
+                            i += 1;
+                            Some(
+                                args.get(i)
+                                    .ok_or_else(|| {
+                                        Error::new(
+                                            ErrorKind::InvalidData,
+                                            format!("Option {name} requires a value"),
+                                        )
+                                    })?
+                                    .to_string(),
+                            )
+                        }
+                    }
+                } else {
+                    if attached.is_some() {
+                        return Err(Error::new(
+                            ErrorKind::InvalidData,
+                            format!("Option {name} does not take a value"),
+                        ));
+                    }
+                    None
+                };
+                self.push_option(&mut out, &mut seen, id, value)?;
+                i += 1;
+                continue;
+            }
+
+            if arg.starts_with('-') {
+                let body = &arg[1..];
+                if body.is_empty() {
+                    out.push(InputToken::Word(arg.to_owned()));
+                    i += 1;
+                    continue;
+                }
+
+                let mut chars = body.char_indices().peekable();
+                let mut consumed_external_value = false;
+                while let Some((offset, ch)) = chars.next() {
+                    if ch == '=' {
+                        return Err(Error::new(
+                            ErrorKind::InvalidData,
+                            format!("Invalid short option cluster: {arg}"),
+                        ));
+                    }
+                    let alias = format!("-{ch}");
+                    let id = self.find(&alias).ok_or_else(|| {
+                        Error::new(ErrorKind::InvalidData, format!("Unknown option: {alias}"))
+                    })?;
+                    let spec = &self.specs[id];
+                    let next_offset = offset + ch.len_utf8();
+                    let rest = &body[next_offset..];
+
+                    if spec.takes_value {
+                        let value = if !rest.is_empty() {
+                            Some(rest.strip_prefix('=').unwrap_or(rest).to_owned())
+                        } else {
+                            i += 1;
+                            consumed_external_value = true;
+                            Some(
+                                args.get(i)
+                                    .ok_or_else(|| {
+                                        Error::new(
+                                            ErrorKind::InvalidData,
+                                            format!("Option {alias} requires a value"),
+                                        )
+                                    })?
+                                    .to_string(),
+                            )
+                        };
+                        self.push_option(&mut out, &mut seen, id, value)?;
+                        break;
+                    }
+
+                    self.push_option(&mut out, &mut seen, id, None)?;
+                }
+
+                let _ = consumed_external_value;
+                i += 1;
+                continue;
+            }
+
+            out.push(InputToken::Word(arg.to_owned()));
+            i += 1;
+        }
+
+        Ok(out)
+    }
+
+    pub fn initial_options(&self) -> Map<String, Value> {
+        self.specs
+            .iter()
+            .map(|spec| {
+                let value = if spec.takes_value {
+                    spec.default_value
+                        .as_ref()
+                        .map_or(Value::Null, |value| Value::String(value.clone()))
+                } else if spec.repeatable {
+                    Value::from(0_u64)
+                } else {
+                    Value::Bool(false)
+                };
+                (spec.key(), value)
+            })
+            .collect()
+    }
+
+    pub fn apply_capture(
+        &self,
+        options: &mut Map<String, Value>,
+        id: usize,
+        value: Option<&str>,
+    ) -> Result<()> {
+        let spec = self.specs.get(id).ok_or_else(|| {
+            Error::new(ErrorKind::InvalidData, format!("Unknown option id {id}"))
+        })?;
+        let key = spec.key();
+        if spec.takes_value {
+            options.insert(
+                key,
+                Value::String(
+                    value
+                        .ok_or_else(|| {
+                            Error::new(
+                                ErrorKind::InvalidData,
+                                format!("Option {} requires a value", spec.preferred_name()),
+                            )
+                        })?
+                        .to_owned(),
+                ),
+            );
+        } else if spec.repeatable {
+            let count = options.get(&key).and_then(Value::as_u64).unwrap_or_default() + 1;
+            options.insert(key, Value::from(count));
+        } else {
+            options.insert(key, Value::Bool(true));
+        }
+        Ok(())
+    }
+
+    pub fn all_ids(&self) -> impl Iterator<Item = usize> + '_ {
+        0..self.specs.len()
+    }
+
+    fn push_option(
+        &self,
+        out: &mut Vec<InputToken>,
+        seen: &mut HashMap<usize, usize>,
+        id: usize,
+        value: Option<String>,
+    ) -> Result<()> {
+        let count = seen.entry(id).or_default();
+        *count += 1;
+        if *count > 1 && !self.specs[id].repeatable {
+            return Err(Error::new(
+                ErrorKind::InvalidData,
+                format!(
+                    "Option {} cannot be repeated",
+                    self.specs[id].preferred_name()
+                ),
+            ));
+        }
+        out.push(InputToken::Option { id, value });
+        Ok(())
+    }
+
+    fn find(&self, alias: &str) -> Option<usize> {
+        self.aliases.get(alias).copied()
+    }
+
+    fn add_description_line(&mut self, line: &str) -> Result<()> {
+        let (declaration, description) = line.split_once("  ").unwrap_or((line, ""));
+        let declaration = declaration.replace(',', " ");
+        let mut short = None;
+        let mut long = None;
+        let mut takes_value = false;
+
+        for word in declaration.split_whitespace() {
+            if word.starts_with("--") {
+                let (name, has_value) = split_option_declaration(word);
+                long = Some(name);
+                takes_value |= has_value;
+            } else if word.starts_with('-') {
+                let (name, has_value) = split_option_declaration(word);
+                short = Some(name);
+                takes_value |= has_value;
+            } else {
+                takes_value = true;
+            }
+        }
+
+        if short.is_none() && long.is_none() {
+            return Ok(());
+        }
+
+        let default_value = RE_DEFAULT_VALUE
+            .captures(description)
+            .and_then(|captures| captures.get(1))
+            .map(|value| value.as_str().to_owned());
+
+        self.upsert(OptionSpec {
+            short,
+            long,
+            takes_value,
+            default_value,
+            repeatable: false,
+        })?;
+        Ok(())
+    }
+
+    fn discover_usage_options(&mut self, usage: &str) -> Result<()> {
+        let words = usage
+            .replace(['[', ']', '(', ')', '|'], " ")
+            .split_whitespace()
+            .map(|word| word.strip_suffix("...").unwrap_or(word).to_owned())
+            .collect::<Vec<_>>();
+
+        for word in words {
+            if word.starts_with("--") && word != "--" {
+                let (name, has_value) = split_option_declaration(&word);
+                self.upsert(OptionSpec {
+                    short: None,
+                    long: Some(name),
+                    takes_value: has_value,
+                    default_value: None,
+                    repeatable: false,
+                })?;
+            } else if word.starts_with('-') && word != "-" {
+                self.discover_short_cluster(&word)?;
+            }
+        }
+        Ok(())
+    }
+
+    fn discover_short_cluster(&mut self, word: &str) -> Result<()> {
+        let body = &word[1..];
+        let mut chars = body.char_indices().peekable();
+        while let Some((offset, ch)) = chars.next() {
+            if ch == '=' {
+                break;
+            }
+            let alias = format!("-{ch}");
+            let next_offset = offset + ch.len_utf8();
+            let rest = &body[next_offset..];
+
+            if let Some(id) = self.find(&alias) {
+                if self.specs[id].takes_value {
+                    break;
+                }
+                continue;
+            }
+
+            let takes_value = rest.starts_with('=');
+            self.upsert(OptionSpec {
+                short: Some(alias),
+                long: None,
+                takes_value,
+                default_value: None,
+                repeatable: false,
+            })?;
+            if takes_value {
+                break;
+            }
+        }
+        Ok(())
+    }
+
+    fn expand_usage_option(&self, atom: &str) -> Result<(Vec<usize>, bool)> {
+        if atom.starts_with("--") {
+            let name = atom.split_once('=').map_or(atom, |(name, _)| name);
+            let id = self.find(name).ok_or_else(|| {
+                Error::new(ErrorKind::InvalidData, format!("Unknown option: {name}"))
+            })?;
+            let spec = &self.specs[id];
+            return Ok((vec![id], spec.takes_value && !atom.contains('=')));
+        }
+
+        let body = atom.strip_prefix('-').unwrap_or(atom);
+        let mut ids = Vec::new();
+        let mut consume_next = false;
+        for (offset, ch) in body.char_indices() {
+            if ch == '=' {
+                break;
+            }
+            let alias = format!("-{ch}");
+            let id = self.find(&alias).ok_or_else(|| {
+                Error::new(ErrorKind::InvalidData, format!("Unknown option: {alias}"))
+            })?;
+            ids.push(id);
+            if self.specs[id].takes_value {
+                let next_offset = offset + ch.len_utf8();
+                consume_next = body[next_offset..].is_empty();
+                break;
+            }
+        }
+        if ids.is_empty() {
+            return Err(Error::new(
+                ErrorKind::InvalidData,
+                format!("Invalid option in usage: {atom}"),
+            ));
+        }
+        Ok((ids, consume_next))
+    }
+
+    fn upsert(&mut self, incoming: OptionSpec) -> Result<usize> {
+        let existing = incoming
+            .short
+            .as_ref()
+            .and_then(|alias| self.find(alias))
+            .or_else(|| incoming.long.as_ref().and_then(|alias| self.find(alias)));
+
+        if let Some(id) = existing {
+            let spec = &mut self.specs[id];
+            if let (Some(a), Some(b)) = (&spec.short, &incoming.short)
+                && a != b
+            {
+                return Err(Error::new(
+                    ErrorKind::InvalidData,
+                    format!("Conflicting short option aliases: {a} and {b}"),
+                ));
+            }
+            if let (Some(a), Some(b)) = (&spec.long, &incoming.long)
+                && a != b
+            {
+                return Err(Error::new(
+                    ErrorKind::InvalidData,
+                    format!("Conflicting long option aliases: {a} and {b}"),
+                ));
+            }
+            if let (Some(a), Some(b)) = (&spec.default_value, &incoming.default_value)
+                && a != b
+            {
+                return Err(Error::new(
+                    ErrorKind::InvalidData,
+                    format!("Conflicting defaults for option {}", spec.preferred_name()),
+                ));
+            }
+
+            if spec.short.is_none() {
+                spec.short = incoming.short.clone();
+            }
+            if spec.long.is_none() {
+                spec.long = incoming.long.clone();
+            }
+            spec.takes_value |= incoming.takes_value;
+            if spec.default_value.is_none() {
+                spec.default_value = incoming.default_value.clone();
+            }
+            if let Some(alias) = &spec.short {
+                self.aliases.insert(alias.clone(), id);
+            }
+            if let Some(alias) = &spec.long {
+                self.aliases.insert(alias.clone(), id);
+            }
+            return Ok(id);
+        }
+
+        let id = self.specs.len();
+        if let Some(alias) = &incoming.short {
+            if self.aliases.insert(alias.clone(), id).is_some() {
+                return Err(Error::new(
+                    ErrorKind::InvalidData,
+                    format!("Duplicate option alias: {alias}"),
+                ));
+            }
+        }
+        if let Some(alias) = &incoming.long {
+            if self.aliases.insert(alias.clone(), id).is_some() {
+                return Err(Error::new(
+                    ErrorKind::InvalidData,
+                    format!("Duplicate option alias: {alias}"),
+                ));
+            }
+        }
+        self.specs.push(incoming);
+        Ok(id)
+    }
+}
+
+fn split_option_declaration(value: &str) -> (String, bool) {
+    match value.split_once('=') {
+        Some((name, _)) => (name.to_owned(), true),
+        None => (value.to_owned(), false),
+    }
+}
+
+fn lex_usage(usage: &str) -> Result<Vec<Token>> {
+    let chars = usage.char_indices().collect::<Vec<_>>();
+    let mut tokens = Vec::new();
+    let mut current = String::new();
+    let mut i = 0;
+
+    let flush = |current: &mut String, tokens: &mut Vec<Token>| {
+        if !current.is_empty() {
+            tokens.push(Token::Atom(std::mem::take(current)));
+        }
+    };
+
+    while i < chars.len() {
+        let (_, ch) = chars[i];
+        if ch.is_whitespace() {
+            flush(&mut current, &mut tokens);
+            i += 1;
+            continue;
+        }
+        if matches!(ch, '[' | ']' | '(' | ')' | '|') {
+            flush(&mut current, &mut tokens);
+            tokens.push(match ch {
+                '[' => Token::LeftBracket,
+                ']' => Token::RightBracket,
+                '(' => Token::LeftParen,
+                ')' => Token::RightParen,
+                '|' => Token::Pipe,
+                _ => unreachable!(),
+            });
+            i += 1;
+            continue;
+        }
+        if ch == '.' && i + 2 < chars.len() && chars[i + 1].1 == '.' && chars[i + 2].1 == '.' {
+            flush(&mut current, &mut tokens);
+            tokens.push(Token::Ellipsis);
+            i += 3;
+            continue;
+        }
+        current.push(ch);
+        i += 1;
+    }
+    flush(&mut current, &mut tokens);
+
+    if tokens.is_empty() {
+        return Err(Error::new(ErrorKind::InvalidData, "Empty usage pattern"));
+    }
+    Ok(tokens)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn normalizes_short_cluster_with_value() {
+        let help = "Usage: tool [-vfo FILE]\n\n-v --verbose  verbose\n-f --force  force\n-o FILE  output";
+        let usages = vec!["tool [-vfo FILE]".to_owned()];
+        let registry = OptionRegistry::from_doc(help, &usages).unwrap();
+        let tokens = registry.tokenize_usage(&usages[0]).unwrap();
+        assert!(matches!(tokens[1], Token::Option(_)));
+    }
+
+    #[test]
+    fn normalizes_runtime_options() {
+        let help = "Usage: tool [options] <file>\n\n-v --verbose  verbose\n-o FILE  output";
+        let usages = vec!["tool [options] <file>".to_owned()];
+        let registry = OptionRegistry::from_doc(help, &usages).unwrap();
+        let input = registry.normalize_args(&["-v", "-oout", "file"]).unwrap();
+        assert_eq!(input.len(), 3);
+    }
+}

--- a/rash_core/src/script_cli/options.rs
+++ b/rash_core/src/script_cli/options.rs
@@ -126,7 +126,6 @@ impl OptionRegistry {
 
     pub fn normalize_args(&self, args: &[&str]) -> Result<Vec<InputToken>> {
         let mut out = Vec::with_capacity(args.len());
-        let mut seen = HashMap::<usize, usize>::new();
         let mut i = 0;
 
         while i < args.len() {
@@ -175,7 +174,7 @@ impl OptionRegistry {
                     }
                     None
                 };
-                self.push_option(&mut out, &mut seen, id, value)?;
+                self.push_option(&mut out, id, value);
                 i += 1;
                 continue;
             }
@@ -188,9 +187,7 @@ impl OptionRegistry {
                     continue;
                 }
 
-                let mut chars = body.char_indices().peekable();
-                let mut consumed_external_value = false;
-                while let Some((offset, ch)) = chars.next() {
+                for (offset, ch) in body.char_indices() {
                     if ch == '=' {
                         return Err(Error::new(
                             ErrorKind::InvalidData,
@@ -210,7 +207,6 @@ impl OptionRegistry {
                             Some(rest.strip_prefix('=').unwrap_or(rest).to_owned())
                         } else {
                             i += 1;
-                            consumed_external_value = true;
                             Some(
                                 args.get(i)
                                     .ok_or_else(|| {
@@ -222,14 +218,13 @@ impl OptionRegistry {
                                     .to_string(),
                             )
                         };
-                        self.push_option(&mut out, &mut seen, id, value)?;
+                        self.push_option(&mut out, id, value);
                         break;
                     }
 
-                    self.push_option(&mut out, &mut seen, id, None)?;
+                    self.push_option(&mut out, id, None);
                 }
 
-                let _ = consumed_external_value;
                 i += 1;
                 continue;
             }
@@ -265,9 +260,10 @@ impl OptionRegistry {
         id: usize,
         value: Option<&str>,
     ) -> Result<()> {
-        let spec = self.specs.get(id).ok_or_else(|| {
-            Error::new(ErrorKind::InvalidData, format!("Unknown option id {id}"))
-        })?;
+        let spec = self
+            .specs
+            .get(id)
+            .ok_or_else(|| Error::new(ErrorKind::InvalidData, format!("Unknown option id {id}")))?;
         let key = spec.key();
         if spec.takes_value {
             options.insert(
@@ -284,7 +280,11 @@ impl OptionRegistry {
                 ),
             );
         } else if spec.repeatable {
-            let count = options.get(&key).and_then(Value::as_u64).unwrap_or_default() + 1;
+            let count = options
+                .get(&key)
+                .and_then(Value::as_u64)
+                .unwrap_or_default()
+                + 1;
             options.insert(key, Value::from(count));
         } else {
             options.insert(key, Value::Bool(true));
@@ -296,26 +296,8 @@ impl OptionRegistry {
         0..self.specs.len()
     }
 
-    fn push_option(
-        &self,
-        out: &mut Vec<InputToken>,
-        seen: &mut HashMap<usize, usize>,
-        id: usize,
-        value: Option<String>,
-    ) -> Result<()> {
-        let count = seen.entry(id).or_default();
-        *count += 1;
-        if *count > 1 && !self.specs[id].repeatable {
-            return Err(Error::new(
-                ErrorKind::InvalidData,
-                format!(
-                    "Option {} cannot be repeated",
-                    self.specs[id].preferred_name()
-                ),
-            ));
-        }
+    fn push_option(&self, out: &mut Vec<InputToken>, id: usize, value: Option<String>) {
         out.push(InputToken::Option { id, value });
-        Ok(())
     }
 
     fn find(&self, alias: &str) -> Option<usize> {
@@ -388,8 +370,7 @@ impl OptionRegistry {
 
     fn discover_short_cluster(&mut self, word: &str) -> Result<()> {
         let body = &word[1..];
-        let mut chars = body.char_indices().peekable();
-        while let Some((offset, ch)) = chars.next() {
+        for (offset, ch) in body.char_indices() {
             if ch == '=' {
                 break;
             }
@@ -593,7 +574,8 @@ mod tests {
 
     #[test]
     fn normalizes_short_cluster_with_value() {
-        let help = "Usage: tool [-vfo FILE]\n\n-v --verbose  verbose\n-f --force  force\n-o FILE  output";
+        let help =
+            "Usage: tool [-vfo FILE]\n\n-v --verbose  verbose\n-f --force  force\n-o FILE  output";
         let usages = vec!["tool [-vfo FILE]".to_owned()];
         let registry = OptionRegistry::from_doc(help, &usages).unwrap();
         let tokens = registry.tokenize_usage(&usages[0]).unwrap();
@@ -607,5 +589,13 @@ mod tests {
         let registry = OptionRegistry::from_doc(help, &usages).unwrap();
         let input = registry.normalize_args(&["-v", "-oout", "file"]).unwrap();
         assert_eq!(input.len(), 3);
+    }
+
+    #[test]
+    fn repeated_simple_options_are_left_to_the_grammar() {
+        let help = "Usage: tool [options]\n\n-v --verbose  verbose";
+        let usages = vec!["tool [options]".to_owned()];
+        let registry = OptionRegistry::from_doc(help, &usages).unwrap();
+        assert_eq!(registry.normalize_args(&["-vv"]).unwrap().len(), 2);
     }
 }

--- a/rash_core/src/script_cli/options.rs
+++ b/rash_core/src/script_cli/options.rs
@@ -6,6 +6,7 @@ use serde_json::{Map, Value};
 
 use crate::error::{Error, ErrorKind, Result};
 
+use super::grammar::is_lower_word;
 use super::{InputToken, Token};
 
 static RE_DEFAULT_VALUE: LazyLock<Regex> =
@@ -351,6 +352,18 @@ impl OptionRegistry {
         for word in words {
             if word.starts_with("--") && word != "--" {
                 let (name, has_value) = split_option_declaration(&word);
+                let Some(identifier) = name.strip_prefix("--") else {
+                    return Err(Error::new(
+                        ErrorKind::InvalidData,
+                        format!("Invalid long option in usage: {name}"),
+                    ));
+                };
+                if !is_lower_word(identifier) {
+                    return Err(Error::new(
+                        ErrorKind::InvalidData,
+                        format!("Invalid long option in usage: {name}"),
+                    ));
+                }
                 self.upsert(OptionSpec {
                     short: None,
                     long: Some(name),
@@ -370,6 +383,12 @@ impl OptionRegistry {
         for (offset, ch) in body.char_indices() {
             if ch == '=' {
                 break;
+            }
+            if !ch.is_ascii_lowercase() {
+                return Err(Error::new(
+                    ErrorKind::InvalidData,
+                    format!("Invalid short option in usage: -{ch}"),
+                ));
             }
             let alias = format!("-{ch}");
             let next_offset = offset + ch.len_utf8();
@@ -613,6 +632,14 @@ mod tests {
         let registry = OptionRegistry::from_doc(help, &usages).unwrap();
         let tokens = registry.tokenize_usage(&usages[0]).unwrap();
         assert_eq!(tokens.iter().filter(|token| matches!(token, Token::Atom(_))).count(), 0);
+    }
+
+    #[test]
+    fn rejects_usage_option_identifiers_outside_legacy_grammar() {
+        for usage in ["tool [--Foo]", "tool [--foo2]", "tool [-X]"] {
+            let registry = OptionRegistry::from_doc(usage, &[usage.to_owned()]);
+            assert!(registry.is_err(), "usage={usage}");
+        }
     }
 
     #[test]

--- a/rash_core/src/script_cli/options.rs
+++ b/rash_core/src/script_cli/options.rs
@@ -80,16 +80,9 @@ impl OptionRegistry {
                     format!("Unknown option id {id}"),
                 ));
             };
-            if spec.takes_value {
-                return Err(Error::new(
-                    ErrorKind::InvalidData,
-                    format!(
-                        "Repeatable options with values are not supported: {}",
-                        spec.preferred_name()
-                    ),
-                ));
+            if !spec.takes_value {
+                spec.repeatable = true;
             }
-            spec.repeatable = true;
         }
         Ok(())
     }
@@ -613,6 +606,15 @@ mod tests {
         let registry = OptionRegistry::from_doc(help, &usages).unwrap();
         let tokens = registry.tokenize_usage(&usages[0]).unwrap();
         assert_eq!(tokens.iter().filter(|token| matches!(token, Token::Atom(_))).count(), 0);
+    }
+
+    #[test]
+    fn repeatable_value_option_keeps_scalar_output_type() {
+        let help = "Usage: tool [--tag=<value>]...";
+        let usages = vec!["tool [--tag=<value>]...".to_owned()];
+        let mut registry = OptionRegistry::from_doc(help, &usages).unwrap();
+        registry.set_repeatable(&HashSet::from([0])).unwrap();
+        assert_eq!(registry.initial_options()["tag"], Value::Null);
     }
 
     #[test]

--- a/rash_core/src/script_cli/options.rs
+++ b/rash_core/src/script_cli/options.rs
@@ -39,6 +39,7 @@ impl OptionSpec {
 pub(super) struct OptionRegistry {
     specs: Vec<OptionSpec>,
     aliases: HashMap<String, usize>,
+    ambiguous_aliases: HashSet<String>,
 }
 
 impl OptionRegistry {
@@ -142,9 +143,7 @@ impl OptionRegistry {
                     Some((name, value)) => (name, Some(value.to_owned())),
                     None => (arg, None),
                 };
-                let id = self.find(name).ok_or_else(|| {
-                    Error::new(ErrorKind::InvalidData, format!("Unknown option: {name}"))
-                })?;
+                let id = self.resolve(name)?;
                 let spec = &self.specs[id];
                 let value = if spec.takes_value {
                     match attached {
@@ -192,9 +191,7 @@ impl OptionRegistry {
                         ));
                     }
                     let alias = format!("-{ch}");
-                    let id = self.find(&alias).ok_or_else(|| {
-                        Error::new(ErrorKind::InvalidData, format!("Unknown option: {alias}"))
-                    })?;
+                    let id = self.resolve(&alias)?;
                     let spec = &self.specs[id];
                     let next_offset = offset + ch.len_utf8();
                     let rest = &body[next_offset..];
@@ -298,7 +295,23 @@ impl OptionRegistry {
     }
 
     fn find(&self, alias: &str) -> Option<usize> {
-        self.aliases.get(alias).copied()
+        if self.ambiguous_aliases.contains(alias) {
+            None
+        } else {
+            self.aliases.get(alias).copied()
+        }
+    }
+
+    fn resolve(&self, alias: &str) -> Result<usize> {
+        if self.ambiguous_aliases.contains(alias) {
+            return Err(Error::new(
+                ErrorKind::InvalidData,
+                format!("Ambiguous option alias: {alias}"),
+            ));
+        }
+        self.aliases.get(alias).copied().ok_or_else(|| {
+            Error::new(ErrorKind::InvalidData, format!("Unknown option: {alias}"))
+        })
     }
 
     fn add_description_line(&mut self, line: &str) -> Result<()> {
@@ -372,6 +385,9 @@ impl OptionRegistry {
                 break;
             }
             let alias = format!("-{ch}");
+            if self.ambiguous_aliases.contains(&alias) {
+                break;
+            }
             let next_offset = offset + ch.len_utf8();
             let rest = &body[next_offset..];
 
@@ -400,9 +416,7 @@ impl OptionRegistry {
     fn expand_usage_option(&self, atom: &str) -> Result<(Vec<usize>, bool)> {
         if atom.starts_with("--") {
             let name = atom.split_once('=').map_or(atom, |(name, _)| name);
-            let id = self.find(name).ok_or_else(|| {
-                Error::new(ErrorKind::InvalidData, format!("Unknown option: {name}"))
-            })?;
+            let id = self.resolve(name)?;
             let spec = &self.specs[id];
             return Ok((vec![id], spec.takes_value && !atom.contains('=')));
         }
@@ -415,9 +429,7 @@ impl OptionRegistry {
                 break;
             }
             let alias = format!("-{ch}");
-            let id = self.find(&alias).ok_or_else(|| {
-                Error::new(ErrorKind::InvalidData, format!("Unknown option: {alias}"))
-            })?;
+            let id = self.resolve(&alias)?;
             ids.push(id);
             if self.specs[id].takes_value {
                 let next_offset = offset + ch.len_utf8();
@@ -435,15 +447,36 @@ impl OptionRegistry {
     }
 
     fn upsert(&mut self, incoming: OptionSpec) -> Result<usize> {
-        let existing = incoming
-            .short
-            .as_ref()
-            .and_then(|alias| self.find(alias))
-            .or_else(|| incoming.long.as_ref().and_then(|alias| self.find(alias)));
+        let short_existing = incoming.short.as_ref().and_then(|alias| self.find(alias));
+        let long_existing = incoming.long.as_ref().and_then(|alias| self.find(alias));
+        let existing = match (short_existing, long_existing) {
+            (Some(short), Some(long)) if short != long => {
+                return Err(Error::new(
+                    ErrorKind::InvalidData,
+                    format!(
+                        "Option aliases resolve to different options: {} {}",
+                        incoming.short.as_deref().unwrap_or(""),
+                        incoming.long.as_deref().unwrap_or("")
+                    ),
+                ));
+            }
+            (Some(id), _) | (_, Some(id)) => Some(id),
+            (None, None) => None,
+        };
 
         if let Some(id) = existing {
-            let spec = &mut self.specs[id];
-            if let (Some(a), Some(b)) = (&spec.short, &incoming.short)
+            let existing_spec = &self.specs[id];
+            let shared_short_with_distinct_longs = existing_spec.short == incoming.short
+                && existing_spec.short.is_some()
+                && matches!(
+                    (&existing_spec.long, &incoming.long),
+                    (Some(existing_long), Some(incoming_long)) if existing_long != incoming_long
+                );
+            if shared_short_with_distinct_longs {
+                return self.insert_distinct(incoming);
+            }
+
+            if let (Some(a), Some(b)) = (&existing_spec.short, &incoming.short)
                 && a != b
             {
                 return Err(Error::new(
@@ -451,7 +484,7 @@ impl OptionRegistry {
                     format!("Conflicting short option aliases: {a} and {b}"),
                 ));
             }
-            if let (Some(a), Some(b)) = (&spec.long, &incoming.long)
+            if let (Some(a), Some(b)) = (&existing_spec.long, &incoming.long)
                 && a != b
             {
                 return Err(Error::new(
@@ -459,15 +492,16 @@ impl OptionRegistry {
                     format!("Conflicting long option aliases: {a} and {b}"),
                 ));
             }
-            if let (Some(a), Some(b)) = (&spec.default_value, &incoming.default_value)
+            if let (Some(a), Some(b)) = (&existing_spec.default_value, &incoming.default_value)
                 && a != b
             {
                 return Err(Error::new(
                     ErrorKind::InvalidData,
-                    format!("Conflicting defaults for option {}", spec.preferred_name()),
+                    format!("Conflicting defaults for option {}", existing_spec.preferred_name()),
                 ));
             }
 
+            let spec = &mut self.specs[id];
             if spec.short.is_none() {
                 spec.short = incoming.short.clone();
             }
@@ -478,31 +512,44 @@ impl OptionRegistry {
             if spec.default_value.is_none() {
                 spec.default_value = incoming.default_value.clone();
             }
-            if let Some(alias) = &spec.short {
+            if let Some(alias) = &spec.short
+                && !self.ambiguous_aliases.contains(alias)
+            {
                 self.aliases.insert(alias.clone(), id);
             }
-            if let Some(alias) = &spec.long {
+            if let Some(alias) = &spec.long
+                && !self.ambiguous_aliases.contains(alias)
+            {
                 self.aliases.insert(alias.clone(), id);
             }
             return Ok(id);
         }
 
+        self.insert_distinct(incoming)
+    }
+
+    fn insert_distinct(&mut self, incoming: OptionSpec) -> Result<usize> {
         let id = self.specs.len();
-        if let Some(alias) = &incoming.short
-            && self.aliases.insert(alias.clone(), id).is_some()
-        {
+        let aliases = [incoming.short.as_ref(), incoming.long.as_ref()]
+            .into_iter()
+            .flatten()
+            .collect::<Vec<_>>();
+        let has_unique_alias = aliases
+            .iter()
+            .any(|alias| !self.aliases.contains_key(alias.as_str()));
+        if !has_unique_alias && aliases.iter().any(|alias| self.ambiguous_aliases.contains(*alias)) {
             return Err(Error::new(
                 ErrorKind::InvalidData,
-                format!("Duplicate option alias: {alias}"),
+                format!("Option has no unambiguous alias: {}", incoming.preferred_name()),
             ));
         }
-        if let Some(alias) = &incoming.long
-            && self.aliases.insert(alias.clone(), id).is_some()
-        {
-            return Err(Error::new(
-                ErrorKind::InvalidData,
-                format!("Duplicate option alias: {alias}"),
-            ));
+
+        for alias in aliases {
+            if self.aliases.contains_key(alias.as_str()) {
+                self.ambiguous_aliases.insert(alias.clone());
+            } else {
+                self.aliases.insert(alias.clone(), id);
+            }
         }
         self.specs.push(incoming);
         Ok(id)
@@ -626,17 +673,43 @@ mod tests {
 
     #[test]
     fn positional_help_distinguishes_short_only_h_from_other_aliases() {
-        let short_only = OptionRegistry::from_doc("Usage: tool <value>\n\n-h  helpish", &["tool <value>".to_owned()]).unwrap();
+        let short_only = OptionRegistry::from_doc(
+            "Usage: tool <value>\n\n-h  helpish",
+            &["tool <value>".to_owned()],
+        )
+        .unwrap();
         assert!(short_only.is_positional_help(0));
         assert!(!short_only.is_help(0));
 
-        let real_help = OptionRegistry::from_doc("Usage: tool <value>\n\n-h --help  help", &["tool <value>".to_owned()]).unwrap();
+        let real_help = OptionRegistry::from_doc(
+            "Usage: tool <value>\n\n-h --help  help",
+            &["tool <value>".to_owned()],
+        )
+        .unwrap();
         assert!(real_help.is_positional_help(0));
         assert!(real_help.is_help(0));
 
-        let host = OptionRegistry::from_doc("Usage: tool <value>\n\n-h --host  host", &["tool <value>".to_owned()]).unwrap();
+        let host = OptionRegistry::from_doc(
+            "Usage: tool <value>\n\n-h --host  host",
+            &["tool <value>".to_owned()],
+        )
+        .unwrap();
         assert!(!host.is_positional_help(0));
         assert!(!host.is_help(0));
+    }
+
+    #[test]
+    fn shared_short_alias_is_kept_as_deterministic_ambiguity() {
+        let help = "Usage: tool [options]\n\n-u --sysupgrade  upgrade\n-u --upgrades  list upgrades";
+        let usages = vec!["tool [options]".to_owned()];
+        let registry = OptionRegistry::from_doc(help, &usages).unwrap();
+        assert!(registry.normalize_args(&["--sysupgrade"]).is_ok());
+        assert!(registry.normalize_args(&["--upgrades"]).is_ok());
+        let error = registry.normalize_args(&["-u"]).unwrap_err();
+        assert!(error.to_string().contains("Ambiguous option alias: -u"));
+        let initial = registry.initial_options();
+        assert!(initial.contains_key("sysupgrade"));
+        assert!(initial.contains_key("upgrades"));
     }
 
     #[test]

--- a/rash_core/src/script_cli/options.rs
+++ b/rash_core/src/script_cli/options.rs
@@ -309,9 +309,10 @@ impl OptionRegistry {
                 format!("Ambiguous option alias: {alias}"),
             ));
         }
-        self.aliases.get(alias).copied().ok_or_else(|| {
-            Error::new(ErrorKind::InvalidData, format!("Unknown option: {alias}"))
-        })
+        self.aliases
+            .get(alias)
+            .copied()
+            .ok_or_else(|| Error::new(ErrorKind::InvalidData, format!("Unknown option: {alias}")))
     }
 
     fn add_description_line(&mut self, line: &str) -> Result<()> {
@@ -497,7 +498,10 @@ impl OptionRegistry {
             {
                 return Err(Error::new(
                     ErrorKind::InvalidData,
-                    format!("Conflicting defaults for option {}", existing_spec.preferred_name()),
+                    format!(
+                        "Conflicting defaults for option {}",
+                        existing_spec.preferred_name()
+                    ),
                 ));
             }
 
@@ -537,10 +541,17 @@ impl OptionRegistry {
         let has_unique_alias = aliases
             .iter()
             .any(|alias| !self.aliases.contains_key(alias.as_str()));
-        if !has_unique_alias && aliases.iter().any(|alias| self.ambiguous_aliases.contains(*alias)) {
+        if !has_unique_alias
+            && aliases
+                .iter()
+                .any(|alias| self.ambiguous_aliases.contains(*alias))
+        {
             return Err(Error::new(
                 ErrorKind::InvalidData,
-                format!("Option has no unambiguous alias: {}", incoming.preferred_name()),
+                format!(
+                    "Option has no unambiguous alias: {}",
+                    incoming.preferred_name()
+                ),
             ));
         }
 
@@ -659,7 +670,13 @@ mod tests {
         let usages = vec!["tool [-o FILE]".to_owned()];
         let registry = OptionRegistry::from_doc(help, &usages).unwrap();
         let tokens = registry.tokenize_usage(&usages[0]).unwrap();
-        assert_eq!(tokens.iter().filter(|token| matches!(token, Token::Atom(_))).count(), 0);
+        assert_eq!(
+            tokens
+                .iter()
+                .filter(|token| matches!(token, Token::Atom(_)))
+                .count(),
+            0
+        );
     }
 
     #[test]
@@ -700,7 +717,8 @@ mod tests {
 
     #[test]
     fn shared_short_alias_is_kept_as_deterministic_ambiguity() {
-        let help = "Usage: tool [options]\n\n-u --sysupgrade  upgrade\n-u --upgrades  list upgrades";
+        let help =
+            "Usage: tool [options]\n\n-u --sysupgrade  upgrade\n-u --upgrades  list upgrades";
         let usages = vec!["tool [options]".to_owned()];
         let registry = OptionRegistry::from_doc(help, &usages).unwrap();
         assert!(registry.normalize_args(&["--sysupgrade"]).is_ok());

--- a/rash_core/src/script_cli/options.rs
+++ b/rash_core/src/script_cli/options.rs
@@ -348,24 +348,28 @@ impl OptionRegistry {
             .map(|word| word.strip_suffix("...").unwrap_or(word).to_owned())
             .collect::<Vec<_>>();
 
-        for word in words {
+        for (index, word) in words.iter().enumerate() {
+            let followed_by_value = words
+                .get(index + 1)
+                .is_some_and(|next| is_value_placeholder(next));
+
             if word.starts_with("--") && word != "--" {
-                let (name, has_value) = split_option_declaration(&word);
+                let (name, has_inline_value) = split_option_declaration(word);
                 self.upsert(OptionSpec {
                     short: None,
                     long: Some(name),
-                    takes_value: has_value,
+                    takes_value: has_inline_value || followed_by_value,
                     default_value: None,
                     repeatable: false,
                 })?;
             } else if word.starts_with('-') && word != "-" {
-                self.discover_short_cluster(&word)?;
+                self.discover_short_cluster(word, followed_by_value)?;
             }
         }
         Ok(())
     }
 
-    fn discover_short_cluster(&mut self, word: &str) -> Result<()> {
+    fn discover_short_cluster(&mut self, word: &str, followed_by_value: bool) -> Result<()> {
         let body = &word[1..];
         for (offset, ch) in body.char_indices() {
             if ch == '=' {
@@ -374,15 +378,19 @@ impl OptionRegistry {
             let alias = format!("-{ch}");
             let next_offset = offset + ch.len_utf8();
             let rest = &body[next_offset..];
+            let takes_value = rest.starts_with('=') || (rest.is_empty() && followed_by_value);
 
             if let Some(id) = self.find(&alias) {
+                if takes_value {
+                    self.specs[id].takes_value = true;
+                    break;
+                }
                 if self.specs[id].takes_value {
                     break;
                 }
                 continue;
             }
 
-            let takes_value = rest.starts_with('=');
             self.upsert(OptionSpec {
                 short: Some(alias),
                 long: None,
@@ -513,7 +521,10 @@ fn is_usage_value_placeholder(token: Option<&Token>) -> bool {
     let Some(Token::Atom(value)) = token else {
         return false;
     };
+    is_value_placeholder(value)
+}
 
+fn is_value_placeholder(value: &str) -> bool {
     if value.starts_with('<') && value.ends_with('>') {
         return true;
     }
@@ -612,7 +623,43 @@ mod tests {
         let usages = vec!["tool [-o FILE]".to_owned()];
         let registry = OptionRegistry::from_doc(help, &usages).unwrap();
         let tokens = registry.tokenize_usage(&usages[0]).unwrap();
-        assert_eq!(tokens.iter().filter(|token| matches!(token, Token::Atom(_))).count(), 0);
+        assert_eq!(
+            tokens
+                .iter()
+                .filter(|token| matches!(token, Token::Atom(_)))
+                .count(),
+            0
+        );
+    }
+
+    #[test]
+    fn infers_short_value_arity_from_usage_without_description() {
+        let help = "Usage: tool [-o FILE]";
+        let usages = vec!["tool [-o FILE]".to_owned()];
+        let registry = OptionRegistry::from_doc(help, &usages).unwrap();
+        let input = registry.normalize_args(&["-o", "out"]).unwrap();
+        assert_eq!(input.len(), 1);
+        assert!(registry.tokenize_usage(&usages[0]).is_ok());
+    }
+
+    #[test]
+    fn infers_long_value_arity_from_usage_without_description() {
+        let help = "Usage: tool [--env VALUE]";
+        let usages = vec!["tool [--env VALUE]".to_owned()];
+        let registry = OptionRegistry::from_doc(help, &usages).unwrap();
+        let input = registry.normalize_args(&["--env", "prod"]).unwrap();
+        assert_eq!(input.len(), 1);
+        assert!(registry.tokenize_usage(&usages[0]).is_ok());
+    }
+
+    #[test]
+    fn infers_cluster_tail_value_arity_from_usage_without_description() {
+        let help = "Usage: tool [-vo FILE]";
+        let usages = vec!["tool [-vo FILE]".to_owned()];
+        let registry = OptionRegistry::from_doc(help, &usages).unwrap();
+        let input = registry.normalize_args(&["-vo", "out"]).unwrap();
+        assert_eq!(input.len(), 2);
+        assert!(registry.tokenize_usage(&usages[0]).is_ok());
     }
 
     #[test]

--- a/rash_core/src/script_cli/options.rs
+++ b/rash_core/src/script_cli/options.rs
@@ -348,28 +348,24 @@ impl OptionRegistry {
             .map(|word| word.strip_suffix("...").unwrap_or(word).to_owned())
             .collect::<Vec<_>>();
 
-        for (index, word) in words.iter().enumerate() {
-            let followed_by_value = words
-                .get(index + 1)
-                .is_some_and(|next| is_value_placeholder(next));
-
+        for word in words {
             if word.starts_with("--") && word != "--" {
-                let (name, has_inline_value) = split_option_declaration(word);
+                let (name, has_value) = split_option_declaration(&word);
                 self.upsert(OptionSpec {
                     short: None,
                     long: Some(name),
-                    takes_value: has_inline_value || followed_by_value,
+                    takes_value: has_value,
                     default_value: None,
                     repeatable: false,
                 })?;
             } else if word.starts_with('-') && word != "-" {
-                self.discover_short_cluster(word, followed_by_value)?;
+                self.discover_short_cluster(&word)?;
             }
         }
         Ok(())
     }
 
-    fn discover_short_cluster(&mut self, word: &str, followed_by_value: bool) -> Result<()> {
+    fn discover_short_cluster(&mut self, word: &str) -> Result<()> {
         let body = &word[1..];
         for (offset, ch) in body.char_indices() {
             if ch == '=' {
@@ -378,19 +374,15 @@ impl OptionRegistry {
             let alias = format!("-{ch}");
             let next_offset = offset + ch.len_utf8();
             let rest = &body[next_offset..];
-            let takes_value = rest.starts_with('=') || (rest.is_empty() && followed_by_value);
 
             if let Some(id) = self.find(&alias) {
-                if takes_value {
-                    self.specs[id].takes_value = true;
-                    break;
-                }
                 if self.specs[id].takes_value {
                     break;
                 }
                 continue;
             }
 
+            let takes_value = rest.starts_with('=');
             self.upsert(OptionSpec {
                 short: Some(alias),
                 long: None,
@@ -521,10 +513,7 @@ fn is_usage_value_placeholder(token: Option<&Token>) -> bool {
     let Some(Token::Atom(value)) = token else {
         return false;
     };
-    is_value_placeholder(value)
-}
 
-fn is_value_placeholder(value: &str) -> bool {
     if value.starts_with('<') && value.ends_with('>') {
         return true;
     }
@@ -623,43 +612,7 @@ mod tests {
         let usages = vec!["tool [-o FILE]".to_owned()];
         let registry = OptionRegistry::from_doc(help, &usages).unwrap();
         let tokens = registry.tokenize_usage(&usages[0]).unwrap();
-        assert_eq!(
-            tokens
-                .iter()
-                .filter(|token| matches!(token, Token::Atom(_)))
-                .count(),
-            0
-        );
-    }
-
-    #[test]
-    fn infers_short_value_arity_from_usage_without_description() {
-        let help = "Usage: tool [-o FILE]";
-        let usages = vec!["tool [-o FILE]".to_owned()];
-        let registry = OptionRegistry::from_doc(help, &usages).unwrap();
-        let input = registry.normalize_args(&["-o", "out"]).unwrap();
-        assert_eq!(input.len(), 1);
-        assert!(registry.tokenize_usage(&usages[0]).is_ok());
-    }
-
-    #[test]
-    fn infers_long_value_arity_from_usage_without_description() {
-        let help = "Usage: tool [--env VALUE]";
-        let usages = vec!["tool [--env VALUE]".to_owned()];
-        let registry = OptionRegistry::from_doc(help, &usages).unwrap();
-        let input = registry.normalize_args(&["--env", "prod"]).unwrap();
-        assert_eq!(input.len(), 1);
-        assert!(registry.tokenize_usage(&usages[0]).is_ok());
-    }
-
-    #[test]
-    fn infers_cluster_tail_value_arity_from_usage_without_description() {
-        let help = "Usage: tool [-vo FILE]";
-        let usages = vec!["tool [-vo FILE]".to_owned()];
-        let registry = OptionRegistry::from_doc(help, &usages).unwrap();
-        let input = registry.normalize_args(&["-vo", "out"]).unwrap();
-        assert_eq!(input.len(), 2);
-        assert!(registry.tokenize_usage(&usages[0]).is_ok());
+        assert_eq!(tokens.iter().filter(|token| matches!(token, Token::Atom(_))).count(), 0);
     }
 
     #[test]

--- a/rash_core/src/script_cli/options.rs
+++ b/rash_core/src/script_cli/options.rs
@@ -75,9 +75,10 @@ impl OptionRegistry {
 
     pub fn is_positional_help(&self, id: usize) -> bool {
         self.is_help(id)
-            || self.specs.get(id).is_some_and(|spec| {
-                spec.long.is_none() && spec.short.as_deref() == Some("-h")
-            })
+            || self
+                .specs
+                .get(id)
+                .is_some_and(|spec| spec.long.is_none() && spec.short.as_deref() == Some("-h"))
     }
 
     pub fn set_repeatable(&mut self, ids: &HashSet<usize>) -> Result<()> {

--- a/rash_core/tests/script_cli_complex_matrix.rs
+++ b/rash_core/tests/script_cli_complex_matrix.rs
@@ -1,0 +1,108 @@
+use rash_core::{docopt, script_cli};
+
+fn assert_parity(file: &str, args: &[&str]) {
+    let legacy = docopt::parse(file, args);
+    let compiled = script_cli::parse(file, args);
+    match (legacy, compiled) {
+        (Ok(legacy), Ok(compiled)) => assert_eq!(compiled, legacy, "args={args:?}"),
+        (Err(legacy), Err(compiled)) => {
+            assert_eq!(compiled.kind(), legacy.kind(), "args={args:?}")
+        }
+        (legacy, compiled) => {
+            panic!("parser mismatch for args={args:?}: legacy={legacy:?} compiled={compiled:?}")
+        }
+    }
+}
+
+#[test]
+fn complex_option_clusters_and_defaults_match_legacy() {
+    let file = r#"
+#!/usr/bin/env rash
+#
+# Usage:
+#   ./tool [options] <file>
+#
+# Options:
+#   -v, --verbose            Show detailed output
+#   -f, --format=<format>    Output format [default: json]
+#   -r, --repeat=<n>         Repeat operation n times [default: 1]
+#   -q, --quiet              Suppress output
+#
+"#;
+
+    assert_parity(file, &["-vfyaml", "-r5", "-q", "data.txt"]);
+    assert_parity(file, &["--format=xml", "--repeat=3", "data.txt"]);
+    assert_parity(file, &["--format", "yaml", "data.txt"]);
+}
+
+#[test]
+fn nested_groups_with_repeatable_positionals_match_legacy() {
+    let file = r#"
+#!/usr/bin/env rash
+#
+# Usage:
+#   ./tool [options] (add [<item>...] | (remove|delete) <id>)
+#
+# Options:
+#   -f, --force    Force operation
+#
+"#;
+
+    assert_parity(file, &["--force", "add", "item1", "item2", "item3"]);
+    assert_parity(file, &["add"]);
+    assert_parity(file, &["remove", "12345"]);
+    assert_parity(file, &["delete", "12345"]);
+}
+
+#[test]
+fn combined_multi_usage_patterns_match_legacy() {
+    let file = r#"
+#!/usr/bin/env rash
+#
+# Usage:
+#   ./tool deploy [--env=<environment>] [--dry-run] [<service>...]
+#   ./tool rollback [--force] <version>
+#   ./tool (start|stop|restart) [(--all | <service>...)]
+#
+# Options:
+#   --env=<environment>  Target environment [default: dev]
+#   --dry-run            Don't actually deploy
+#   --force              Force the operation
+#   --all                Apply to all services
+#
+"#;
+
+    for args in [
+        vec!["deploy", "--env=prod", "--dry-run", "web", "api", "db"],
+        vec!["deploy"],
+        vec!["rollback", "--force", "v1.2.3"],
+        vec!["start", "web", "api"],
+        vec!["start", "--all"],
+        vec!["restart"],
+    ] {
+        assert_parity(file, &args);
+    }
+}
+
+#[test]
+fn mixed_required_optional_and_alternative_groups_match_legacy() {
+    let file = r#"
+#!/usr/bin/env rash
+#
+# Usage:
+#   ./tool sync (<source> <dest>) [--delete]
+#   ./tool query [--format=<format>] (<key> | --all)
+#
+# Options:
+#   --delete           Delete files missing from source
+#   --format=<format>  Output format [default: text]
+#   --all              Query all values
+#
+"#;
+
+    assert_parity(file, &["sync", "src", "dst"]);
+    assert_parity(file, &["sync", "src", "dst", "--delete"]);
+    assert_parity(file, &["query", "foo"]);
+    assert_parity(file, &["query", "--format=json", "foo"]);
+    assert_parity(file, &["query", "--all"]);
+}

--- a/rash_core/tests/script_cli_complex_matrix.rs
+++ b/rash_core/tests/script_cli_complex_matrix.rs
@@ -85,7 +85,7 @@ fn combined_multi_usage_patterns_match_legacy() {
 }
 
 #[test]
-fn mixed_required_optional_and_alternative_groups_match_legacy() {
+fn mixed_required_optional_and_alternative_groups_match_legacy_except_malformed_option_key() {
     let file = r#"
 #!/usr/bin/env rash
 #
@@ -100,9 +100,32 @@ fn mixed_required_optional_and_alternative_groups_match_legacy() {
 #
 "#;
 
-    assert_parity(file, &["sync", "src", "dst"]);
-    assert_parity(file, &["sync", "src", "dst", "--delete"]);
-    assert_parity(file, &["query", "foo"]);
-    assert_parity(file, &["query", "--format=json", "foo"]);
-    assert_parity(file, &["query", "--all"]);
+    // The legacy usage scanner treats the closing ')' in `--all)` as part of
+    // an option name and injects a spurious `options["all)"] = false` binding.
+    // The compiled parser intentionally fixes that malformed-key behavior.
+    for args in [
+        vec!["sync", "src", "dst"],
+        vec!["sync", "src", "dst", "--delete"],
+        vec!["query", "foo"],
+        vec!["query", "--format=json", "foo"],
+        vec!["query", "--all"],
+    ] {
+        let mut legacy = docopt::parse(file, &args).unwrap();
+        let compiled = script_cli::parse(file, &args).unwrap();
+
+        let legacy_options = legacy
+            .get_mut("options")
+            .and_then(|options| options.as_object_mut())
+            .unwrap();
+        assert!(legacy_options.remove("all)").is_some(), "args={args:?}");
+
+        assert_eq!(compiled, legacy, "args={args:?}");
+        assert!(
+            compiled
+                .get("options")
+                .and_then(|options| options.get("all)"))
+                .is_none(),
+            "compiled parser must not expose malformed option keys; args={args:?}"
+        );
+    }
 }

--- a/rash_core/tests/script_cli_exhaustive.rs
+++ b/rash_core/tests/script_cli_exhaustive.rs
@@ -1,0 +1,117 @@
+use rash_core::{docopt, script_cli};
+
+fn assert_parity(file: &str, args: &[&str]) {
+    let legacy = docopt::parse(file, args);
+    let compiled = script_cli::parse(file, args);
+    match (legacy, compiled) {
+        (Ok(legacy), Ok(compiled)) => assert_eq!(compiled, legacy, "args={args:?}"),
+        (Err(legacy), Err(compiled)) => {
+            assert_eq!(compiled.kind(), legacy.kind(), "args={args:?}")
+        }
+        (legacy, compiled) => {
+            panic!("parser mismatch for args={args:?}: legacy={legacy:?} compiled={compiled:?}")
+        }
+    }
+}
+
+fn enumerate_argv<'a>(alphabet: &'a [&'a str], max_len: usize) -> Vec<Vec<&'a str>> {
+    let mut all = vec![Vec::new()];
+    let mut frontier = vec![Vec::new()];
+
+    for _ in 0..max_len {
+        let mut next = Vec::new();
+        for prefix in frontier {
+            for token in alphabet {
+                let mut argv = prefix.clone();
+                argv.push(*token);
+                all.push(argv.clone());
+                next.push(argv);
+            }
+        }
+        frontier = next;
+    }
+
+    all
+}
+
+#[test]
+fn exhaustive_unordered_optional_flags() {
+    let file = r#"
+#!/usr/bin/env rash
+#
+# Usage: tool [-a] [-b] [-c]
+#
+# Options:
+#   -a --alpha    alpha
+#   -b --beta     beta
+#   -c --charlie  charlie
+#
+"#;
+
+    for args in enumerate_argv(&["-a", "-b", "-c"], 4) {
+        assert_parity(file, &args);
+    }
+}
+
+#[test]
+fn exhaustive_options_shortcut_flags() {
+    let file = r#"
+#!/usr/bin/env rash
+#
+# Usage: tool [options]
+#
+# Options:
+#   -a --alpha  alpha
+#   -b --beta   beta
+#
+"#;
+
+    for args in enumerate_argv(&["-a", "-b", "--alpha", "--beta"], 3) {
+        assert_parity(file, &args);
+    }
+}
+
+#[test]
+fn exhaustive_optional_commands_and_alternative() {
+    let file = r#"
+#!/usr/bin/env rash
+#
+# Usage: tool [prepare] (start|stop) [force]
+#
+"#;
+
+    for args in enumerate_argv(&["prepare", "start", "stop", "force", "other"], 4) {
+        assert_parity(file, &args);
+    }
+}
+
+#[test]
+fn exhaustive_repeated_command_counts() {
+    let file = r#"
+#!/usr/bin/env rash
+#
+# Usage: tool [(a | b)] [(a | b)]
+#
+"#;
+
+    for args in enumerate_argv(&["a", "b", "c"], 3) {
+        assert_parity(file, &args);
+    }
+}
+
+#[test]
+fn exhaustive_option_and_positional_interleaving() {
+    let file = r#"
+#!/usr/bin/env rash
+#
+# Usage: tool <input> [--verbose] [<output>]
+#
+# Options:
+#   -v --verbose  verbose
+#
+"#;
+
+    for args in enumerate_argv(&["in", "out", "-v", "--verbose"], 4) {
+        assert_parity(file, &args);
+    }
+}

--- a/rash_core/tests/script_cli_help.rs
+++ b/rash_core/tests/script_cli_help.rs
@@ -1,7 +1,13 @@
 use rash_core::{docopt, error::ErrorKind, script_cli};
 
+fn assert_error_parity(file: &str, args: &[&str]) {
+    let legacy = docopt::parse(file, args).unwrap_err();
+    let compiled = script_cli::parse(file, args).unwrap_err();
+    assert_eq!(compiled.kind(), legacy.kind(), "args={args:?}");
+}
+
 #[test]
-fn help_option_short_circuits_missing_required_arguments() {
+fn help_option_can_satisfy_a_required_positional_slot() {
     let file = r#"
 #!/usr/bin/env rash
 #
@@ -18,4 +24,40 @@ fn help_option_short_circuits_missing_required_arguments() {
         assert_eq!(legacy.kind(), ErrorKind::GracefulExit);
         assert_eq!(compiled.kind(), legacy.kind());
     }
+}
+
+#[test]
+fn help_option_can_replace_a_positional_after_a_command() {
+    let file = r#"
+#!/usr/bin/env rash
+#
+# Usage:
+#   tool run <target>
+#   tool --help
+#
+# Options:
+#   -h --help  show this help
+#
+"#;
+
+    assert_error_parity(file, &["run", "--help"]);
+    assert_error_parity(file, &["run", "-h"]);
+}
+
+#[test]
+fn impossible_extra_help_is_not_globally_accepted() {
+    let file = r#"
+#!/usr/bin/env rash
+#
+# Usage:
+#   tool run
+#   tool --help
+#
+# Options:
+#   -h --help  show this help
+#
+"#;
+
+    assert_error_parity(file, &["run", "--help"]);
+    assert_error_parity(file, &["run", "-h"]);
 }

--- a/rash_core/tests/script_cli_help.rs
+++ b/rash_core/tests/script_cli_help.rs
@@ -1,0 +1,21 @@
+use rash_core::{docopt, error::ErrorKind, script_cli};
+
+#[test]
+fn help_option_short_circuits_missing_required_arguments() {
+    let file = r#"
+#!/usr/bin/env rash
+#
+# Usage: tool [--help] <required>
+#
+# Options:
+#   -h --help  show this help
+#
+"#;
+
+    for args in [vec!["--help"], vec!["-h"]] {
+        let legacy = docopt::parse(file, &args).unwrap_err();
+        let compiled = script_cli::parse(file, &args).unwrap_err();
+        assert_eq!(legacy.kind(), ErrorKind::GracefulExit);
+        assert_eq!(compiled.kind(), legacy.kind());
+    }
+}

--- a/rash_core/tests/script_cli_help.rs
+++ b/rash_core/tests/script_cli_help.rs
@@ -1,5 +1,19 @@
 use rash_core::{docopt, error::ErrorKind, script_cli};
 
+fn assert_parity(file: &str, args: &[&str]) {
+    let legacy = docopt::parse(file, args);
+    let compiled = script_cli::parse(file, args);
+    match (legacy, compiled) {
+        (Ok(legacy), Ok(compiled)) => assert_eq!(compiled, legacy, "args={args:?}"),
+        (Err(legacy), Err(compiled)) => {
+            assert_eq!(compiled.kind(), legacy.kind(), "args={args:?}")
+        }
+        (legacy, compiled) => {
+            panic!("parser mismatch for args={args:?}: legacy={legacy:?} compiled={compiled:?}")
+        }
+    }
+}
+
 fn assert_error_parity(file: &str, args: &[&str]) {
     let legacy = docopt::parse(file, args).unwrap_err();
     let compiled = script_cli::parse(file, args).unwrap_err();
@@ -60,4 +74,34 @@ fn impossible_extra_help_is_not_globally_accepted() {
 
     assert_error_parity(file, &["run", "--help"]);
     assert_error_parity(file, &["run", "-h"]);
+}
+
+#[test]
+fn short_only_h_can_fill_a_positional_without_graceful_exit() {
+    let file = r#"
+#!/usr/bin/env rash
+#
+# Usage: tool <required>
+#
+# Options:
+#   -h  ordinary h flag
+#
+"#;
+
+    assert_parity(file, &["-h"]);
+}
+
+#[test]
+fn h_with_a_non_help_long_alias_does_not_fill_a_positional() {
+    let file = r#"
+#!/usr/bin/env rash
+#
+# Usage: tool <required>
+#
+# Options:
+#   -h --host  host flag
+#
+"#;
+
+    assert_parity(file, &["-h"]);
 }

--- a/rash_core/tests/script_cli_invalid_grammar.rs
+++ b/rash_core/tests/script_cli_invalid_grammar.rs
@@ -70,7 +70,7 @@ fn punctuation_command_is_not_silently_added_to_the_language() {
 }
 
 #[test]
-fn mixed_case_long_option_is_not_silently_added_to_the_language() {
+fn mixed_case_long_option_preserves_legacy_permissiveness() {
     let file = r#"
 #!/usr/bin/env rash
 #
@@ -81,7 +81,7 @@ fn mixed_case_long_option_is_not_silently_added_to_the_language() {
 }
 
 #[test]
-fn numeric_long_option_suffix_is_not_silently_added_to_the_language() {
+fn numeric_long_option_suffix_preserves_legacy_permissiveness() {
     let file = r#"
 #!/usr/bin/env rash
 #
@@ -92,7 +92,7 @@ fn numeric_long_option_suffix_is_not_silently_added_to_the_language() {
 }
 
 #[test]
-fn uppercase_short_option_is_not_silently_added_to_the_language() {
+fn uppercase_short_option_preserves_legacy_permissiveness() {
     let file = r#"
 #!/usr/bin/env rash
 #

--- a/rash_core/tests/script_cli_invalid_grammar.rs
+++ b/rash_core/tests/script_cli_invalid_grammar.rs
@@ -68,3 +68,36 @@ fn punctuation_command_is_not_silently_added_to_the_language() {
 "#;
     assert_parity(file, &["foo.bar"]);
 }
+
+#[test]
+fn mixed_case_long_option_is_not_silently_added_to_the_language() {
+    let file = r#"
+#!/usr/bin/env rash
+#
+# Usage: tool [--Foo]
+#
+"#;
+    assert_parity(file, &["--Foo"]);
+}
+
+#[test]
+fn numeric_long_option_suffix_is_not_silently_added_to_the_language() {
+    let file = r#"
+#!/usr/bin/env rash
+#
+# Usage: tool [--foo2]
+#
+"#;
+    assert_parity(file, &["--foo2"]);
+}
+
+#[test]
+fn uppercase_short_option_is_not_silently_added_to_the_language() {
+    let file = r#"
+#!/usr/bin/env rash
+#
+# Usage: tool [-X]
+#
+"#;
+    assert_parity(file, &["-X"]);
+}

--- a/rash_core/tests/script_cli_invalid_grammar.rs
+++ b/rash_core/tests/script_cli_invalid_grammar.rs
@@ -1,0 +1,70 @@
+use rash_core::{docopt, script_cli};
+
+fn assert_parity(file: &str, args: &[&str]) {
+    let legacy = docopt::parse(file, args);
+    let compiled = script_cli::parse(file, args);
+    match (legacy, compiled) {
+        (Ok(legacy), Ok(compiled)) => assert_eq!(compiled, legacy, "args={args:?}"),
+        (Err(legacy), Err(compiled)) => {
+            assert_eq!(compiled.kind(), legacy.kind(), "args={args:?}")
+        }
+        (legacy, compiled) => {
+            panic!("parser mismatch for args={args:?}: legacy={legacy:?} compiled={compiled:?}")
+        }
+    }
+}
+
+#[test]
+fn mixed_case_command_is_not_silently_added_to_the_language() {
+    let file = r#"
+#!/usr/bin/env rash
+#
+# Usage: tool Run
+#
+"#;
+    assert_parity(file, &["Run"]);
+}
+
+#[test]
+fn numeric_command_suffix_is_not_silently_added_to_the_language() {
+    let file = r#"
+#!/usr/bin/env rash
+#
+# Usage: tool run2
+#
+"#;
+    assert_parity(file, &["run2"]);
+}
+
+#[test]
+fn uppercase_angle_positional_is_not_silently_added_to_the_language() {
+    let file = r#"
+#!/usr/bin/env rash
+#
+# Usage: tool <FILE>
+#
+"#;
+    assert_parity(file, &["value"]);
+}
+
+#[test]
+fn numeric_angle_positional_is_not_silently_added_to_the_language() {
+    let file = r#"
+#!/usr/bin/env rash
+#
+# Usage: tool <file2>
+#
+"#;
+    assert_parity(file, &["value"]);
+}
+
+#[test]
+fn punctuation_command_is_not_silently_added_to_the_language() {
+    let file = r#"
+#!/usr/bin/env rash
+#
+# Usage: tool foo.bar
+#
+"#;
+    assert_parity(file, &["foo.bar"]);
+}

--- a/rash_core/tests/script_cli_legacy_matrix.rs
+++ b/rash_core/tests/script_cli_legacy_matrix.rs
@@ -1,0 +1,205 @@
+use rash_core::{docopt, script_cli};
+
+fn assert_parity(file: &str, args: &[&str]) {
+    let legacy = docopt::parse(file, args);
+    let compiled = script_cli::parse(file, args);
+    match (legacy, compiled) {
+        (Ok(legacy), Ok(compiled)) => assert_eq!(compiled, legacy, "args={args:?}"),
+        (Err(legacy), Err(compiled)) => {
+            assert_eq!(compiled.kind(), legacy.kind(), "args={args:?}")
+        }
+        (legacy, compiled) => {
+            panic!("parser mismatch for args={args:?}: legacy={legacy:?} compiled={compiled:?}")
+        }
+    }
+}
+
+#[test]
+fn repeatable_commands_keep_count_semantics() {
+    let file = r#"
+#!/usr/bin/env rash
+#
+# Usage:
+#   foo [(a | b)] [(a | b)]
+#
+"#;
+
+    for args in [
+        vec![],
+        vec!["a"],
+        vec!["b"],
+        vec!["a", "a"],
+        vec!["a", "b"],
+        vec!["b", "b"],
+    ] {
+        assert_parity(file, &args);
+    }
+}
+
+#[test]
+fn optional_positional_forms_keep_shape() {
+    let optional = r#"
+#!/usr/bin/env rash
+#
+# Usage: foo [<d>]
+#
+"#;
+    assert_parity(optional, &[]);
+    assert_parity(optional, &["x"]);
+
+    let repeat_inside = r#"
+#!/usr/bin/env rash
+#
+# Usage: foo [<d>...]
+#
+"#;
+    assert_parity(repeat_inside, &[]);
+    assert_parity(repeat_inside, &["x"]);
+    assert_parity(repeat_inside, &["x", "y"]);
+
+    let repeat_outside = r#"
+#!/usr/bin/env rash
+#
+# Usage: foo [<d>]...
+#
+"#;
+    assert_parity(repeat_outside, &[]);
+    assert_parity(repeat_outside, &["x"]);
+    assert_parity(repeat_outside, &["x", "y"]);
+}
+
+#[test]
+fn value_bearing_short_cluster_matches_legacy() {
+    let file = r#"
+#!/usr/bin/env rash
+#
+# Usage: foo [options] <port>
+#
+# Options:
+#   -h --help                show this help message and exit
+#   --version                show version and exit
+#   -n, --number N           use N as a number
+#   -t, --timeout TIMEOUT    set timeout TIMEOUT seconds
+#   --apply                  apply changes to database
+#   -q                       operate in quiet mode
+#
+"#;
+
+    assert_parity(file, &["-qn", "10", "443"]);
+    assert_parity(file, &["-q", "-n10", "443"]);
+    assert_parity(file, &["--number=10", "443"]);
+}
+
+#[test]
+fn invalid_short_options_keep_error_class() {
+    let file = r#"
+#!/usr/bin/env rash
+#
+# Usage: foo [-d]
+#
+"#;
+
+    assert_parity(file, &["-a"]);
+    assert_parity(file, &["-ad"]);
+    assert_parity(file, &["-a", "-d"]);
+}
+
+#[test]
+fn cp_overlapping_usages_keep_repeatable_output_shape() {
+    let file = r#"
+#!/usr/bin/env rash
+#
+# Usage:
+#   cp <source> <dest>
+#   cp <source>... <dest>
+#
+"#;
+
+    assert_parity(file, &["foo", "/tmp"]);
+    assert_parity(file, &["foo", "bar", "/tmp"]);
+    assert_parity(file, &["foo", "bar", "baz", "/tmp"]);
+}
+
+#[test]
+fn option_placeholder_can_be_inferred_from_description() {
+    let file = r#"
+#!/usr/bin/env rash
+#
+# Usage:
+#   ./systemctl [--failed | --type ] (daemon-reload|daemon-reexec|help)
+#
+# Options:
+#   --failed                   Show only failed units
+#   -t, --type=TYPE           List units of a particular type [default: service]
+#
+"#;
+
+    assert_parity(file, &["daemon-reload"]);
+    assert_parity(file, &["--type=timer", "daemon-reexec"]);
+    assert_parity(file, &["--type", "timer", "daemon-reexec"]);
+}
+
+#[test]
+fn command_options_and_positional_options_keep_positions() {
+    let commands = r#"
+#!/usr/bin/env rash
+#
+# Usage:
+#   ./tool [--verbose] (start|stop) [--force]
+#
+# Options:
+#   --verbose  Show detailed output
+#   --force    Force the operation
+#
+"#;
+    assert_parity(commands, &["--verbose", "start", "--force"]);
+    assert_parity(commands, &["stop", "--force"]);
+
+    let positionals = r#"
+#!/usr/bin/env rash
+#
+# Usage:
+#   ./tool <input> [--verbose] <output>
+#
+# Options:
+#   --verbose  Show detailed output
+#
+"#;
+    assert_parity(positionals, &["input.txt", "--verbose", "output.txt"]);
+    assert_parity(positionals, &["input.txt", "output.txt"]);
+}
+
+#[test]
+fn complex_naval_fate_success_and_failure_paths_match() {
+    let file = r#"
+#!/usr/bin/env rash
+#
+# Usage:
+#   naval_fate.rh ship new <name>...
+#   naval_fate.rh ship <name> move <x> <y> [--speed=<kn>]
+#   naval_fate.rh ship shoot <x> <y>
+#   naval_fate.rh mine (set|remove) <x> <y> [--moored|--drifting]
+#   naval_fate.rh -h | --help
+#   naval_fate.rh --version
+#
+# Options:
+#   -h --help        Show this screen.
+#   -v --version     Show version.
+#   -s --speed=<kn>  Speed in knots [default: 10].
+#   --moored         Moored (anchored) mine.
+#   --drifting       Drifting mine.
+#
+"#;
+
+    for args in [
+        vec![],
+        vec!["mine", "set", "10", "50", "--drifting"],
+        vec!["mine", "set", "10", "50", "--speed=50"],
+        vec!["ship", "foo", "move", "2", "3", "-s", "20"],
+        vec!["ship", "foo", "move", "2", "3", "-s20"],
+        vec!["ship", "foo", "move", "2", "3", "-s=20"],
+        vec!["ship", "foo", "move", "2", "3", "-s20", "-x"],
+    ] {
+        assert_parity(file, &args);
+    }
+}

--- a/rash_core/tests/script_cli_nested_optional.rs
+++ b/rash_core/tests/script_cli_nested_optional.rs
@@ -1,0 +1,63 @@
+use rash_core::{docopt, script_cli};
+
+fn assert_parity(file: &str, args: &[&str]) {
+    let legacy = docopt::parse(file, args);
+    let compiled = script_cli::parse(file, args);
+    match (legacy, compiled) {
+        (Ok(legacy), Ok(compiled)) => assert_eq!(compiled, legacy, "args={args:?}"),
+        (Err(legacy), Err(compiled)) => {
+            assert_eq!(compiled.kind(), legacy.kind(), "args={args:?}")
+        }
+        (legacy, compiled) => {
+            panic!("parser mismatch for args={args:?}: legacy={legacy:?} compiled={compiled:?}")
+        }
+    }
+}
+
+#[test]
+fn nested_option_requires_outer_command() {
+    let file = r#"
+#!/usr/bin/env rash
+#
+# Usage: tool [command [--force]]
+#
+# Options:
+#   --force  force
+#
+"#;
+
+    assert_parity(file, &[]);
+    assert_parity(file, &["command"]);
+    assert_parity(file, &["command", "--force"]);
+    assert_parity(file, &["--force"]);
+}
+
+#[test]
+fn nested_positional_requires_outer_command() {
+    let file = r#"
+#!/usr/bin/env rash
+#
+# Usage: tool [command [<value>]]
+#
+"#;
+
+    assert_parity(file, &[]);
+    assert_parity(file, &["command"]);
+    assert_parity(file, &["command", "value"]);
+    assert_parity(file, &["value"]);
+}
+
+#[test]
+fn flat_optional_sequence_stays_independent() {
+    let file = r#"
+#!/usr/bin/env rash
+#
+# Usage: tool [alpha beta]
+#
+"#;
+
+    assert_parity(file, &[]);
+    assert_parity(file, &["alpha"]);
+    assert_parity(file, &["beta"]);
+    assert_parity(file, &["alpha", "beta"]);
+}

--- a/rash_core/tests/script_cli_option_duplicates.rs
+++ b/rash_core/tests/script_cli_option_duplicates.rs
@@ -1,0 +1,69 @@
+use rash_core::{docopt, script_cli};
+
+fn assert_parity(file: &str, args: &[&str]) {
+    let legacy = docopt::parse(file, args);
+    let compiled = script_cli::parse(file, args);
+    match (legacy, compiled) {
+        (Ok(legacy), Ok(compiled)) => assert_eq!(compiled, legacy, "args={args:?}"),
+        (Err(legacy), Err(compiled)) => {
+            assert_eq!(compiled.kind(), legacy.kind(), "args={args:?}")
+        }
+        (legacy, compiled) => {
+            panic!("parser mismatch for args={args:?}: legacy={legacy:?} compiled={compiled:?}")
+        }
+    }
+}
+
+#[test]
+fn duplicate_non_repeatable_explicit_option_matches_legacy() {
+    let file = r#"
+#!/usr/bin/env rash
+#
+# Usage: tool [-a] [-b]
+#
+# Options:
+#   -a --alpha  alpha
+#   -b --beta   beta
+#
+"#;
+
+    assert_parity(file, &["-a", "-a"]);
+    assert_parity(file, &["-b", "-b"]);
+    assert_parity(file, &["-a", "-b", "-a"]);
+}
+
+#[test]
+fn duplicate_non_repeatable_options_shortcut_matches_legacy() {
+    let file = r#"
+#!/usr/bin/env rash
+#
+# Usage: tool [options]
+#
+# Options:
+#   -a --alpha  alpha
+#   -b --beta   beta
+#
+"#;
+
+    assert_parity(file, &["-a", "-a"]);
+    assert_parity(file, &["--alpha", "--alpha"]);
+    assert_parity(file, &["-a", "-b", "-a"]);
+}
+
+#[test]
+fn explicitly_repeatable_option_matches_legacy() {
+    let file = r#"
+#!/usr/bin/env rash
+#
+# Usage: tool [-a]...
+#
+# Options:
+#   -a --alpha  alpha
+#
+"#;
+
+    assert_parity(file, &[]);
+    assert_parity(file, &["-a"]);
+    assert_parity(file, &["-aa"]);
+    assert_parity(file, &["--alpha", "--alpha", "--alpha"]);
+}

--- a/rash_core/tests/script_cli_options_shortcut_parity.rs
+++ b/rash_core/tests/script_cli_options_shortcut_parity.rs
@@ -1,0 +1,51 @@
+use rash_core::{docopt, script_cli};
+
+fn assert_parity(file: &str, args: &[&str]) {
+    let legacy = docopt::parse(file, args);
+    let compiled = script_cli::parse(file, args);
+    match (legacy, compiled) {
+        (Ok(legacy), Ok(compiled)) => assert_eq!(compiled, legacy, "args={args:?}"),
+        (Err(legacy), Err(compiled)) => {
+            assert_eq!(compiled.kind(), legacy.kind(), "args={args:?}")
+        }
+        (legacy, compiled) => {
+            panic!("parser mismatch for args={args:?}: legacy={legacy:?} compiled={compiled:?}")
+        }
+    }
+}
+
+#[test]
+fn one_option_shortcut_rejects_duplicate_non_repeatable_option() {
+    let file = r#"
+#!/usr/bin/env rash
+#
+# Usage: tool [options]
+#
+# Options:
+#   -a --alpha  alpha
+#
+"#;
+
+    assert_parity(file, &[]);
+    assert_parity(file, &["--alpha"]);
+    assert_parity(file, &["--alpha", "--alpha"]);
+}
+
+#[test]
+fn multi_option_shortcut_preserves_legacy_repeated_group_behavior() {
+    let file = r#"
+#!/usr/bin/env rash
+#
+# Usage: tool [options]
+#
+# Options:
+#   -a --alpha  alpha
+#   -b --beta   beta
+#
+"#;
+
+    assert_parity(file, &["--alpha", "--beta"]);
+    assert_parity(file, &["--beta", "--alpha"]);
+    assert_parity(file, &["--alpha", "--alpha"]);
+    assert_parity(file, &["--alpha", "--beta", "--alpha"]);
+}

--- a/rash_core/tests/script_cli_parity.rs
+++ b/rash_core/tests/script_cli_parity.rs
@@ -1,0 +1,252 @@
+use rash_core::{docopt, error::ErrorKind, script_cli};
+use serde_json::Value;
+
+fn assert_parity(file: &str, args: &[&str]) {
+    let legacy = docopt::parse(file, args);
+    let compiled = script_cli::parse(file, args);
+    match (legacy, compiled) {
+        (Ok(legacy), Ok(compiled)) => assert_eq!(compiled, legacy, "args={args:?}"),
+        (Err(legacy), Err(compiled)) => {
+            assert_eq!(compiled.kind(), legacy.kind(), "args={args:?}")
+        }
+        (legacy, compiled) => {
+            panic!("parser mismatch for args={args:?}: legacy={legacy:?} compiled={compiled:?}")
+        }
+    }
+}
+
+#[test]
+fn optional_sequence_is_independent_like_legacy() {
+    let file = r#"
+#!/usr/bin/env rash
+#
+# Usage: tool [alpha beta]
+#
+"#;
+
+    assert_parity(file, &[]);
+    assert_parity(file, &["alpha"]);
+    assert_parity(file, &["beta"]);
+    assert_parity(file, &["alpha", "beta"]);
+}
+
+#[test]
+fn grouped_optional_sequence_remains_atomic() {
+    let file = r#"
+#!/usr/bin/env rash
+#
+# Usage: tool [(alpha beta)]
+#
+"#;
+
+    assert_parity(file, &[]);
+    assert_parity(file, &["alpha", "beta"]);
+    assert_parity(file, &["alpha"]);
+    assert_parity(file, &["beta"]);
+}
+
+#[test]
+fn optional_options_are_order_independent() {
+    let file = r#"
+#!/usr/bin/env rash
+#
+# Usage: tool [-a] [-b] [-c]
+#
+# Options:
+#   -a --alpha  alpha
+#   -b --beta   beta
+#   -c --charlie  charlie
+#
+"#;
+
+    for args in [
+        vec![],
+        vec!["-a"],
+        vec!["-b", "-a"],
+        vec!["--charlie", "--alpha", "--beta"],
+        vec!["-cba"],
+    ] {
+        assert_parity(file, &args);
+    }
+}
+
+#[test]
+fn stacked_short_options_with_value_keep_legacy_semantics() {
+    let file = r#"
+#!/usr/bin/env rash
+#
+# Usage: tool [-vfo FILE] [INPUT ...]
+#
+# Options:
+#   -v --verbose  verbose
+#   -f --force    force
+#   -o FILE       output [default: stdout]
+#
+"#;
+
+    for args in [
+        vec!["-v", "input"],
+        vec!["-o", "result", "input"],
+        vec!["-voresult", "input"],
+        vec!["-fvo=result", "input"],
+    ] {
+        assert_parity(file, &args);
+    }
+}
+
+#[test]
+fn dashed_commands_and_positionals_keep_context_names() {
+    let file = r#"
+#!/usr/bin/env rash
+#
+# Usage: tool (daemon-reload|daemon-reexec) <unit-name>
+#
+"#;
+
+    assert_parity(file, &["daemon-reload", "foo.service"]);
+    assert_parity(file, &["daemon-reexec", "foo.service"]);
+}
+
+#[test]
+fn uppercase_positionals_keep_legacy_shape() {
+    let file = r#"
+#!/usr/bin/env rash
+#
+# Usage: tool SOURCE DEST
+#
+"#;
+
+    assert_parity(file, &["a", "b"]);
+}
+
+#[test]
+fn option_aliases_share_one_output_key() {
+    let file = r#"
+#!/usr/bin/env rash
+#
+# Usage: tool [--dry-run]
+#
+# Options:
+#   -d --dry-run  dry run
+#
+"#;
+
+    assert_parity(file, &["-d"]);
+    assert_parity(file, &["--dry-run"]);
+}
+
+#[test]
+fn option_values_can_contain_equals() {
+    let file = r#"
+#!/usr/bin/env rash
+#
+# Usage: tool [--env=<key=value>]
+#
+"#;
+
+    assert_parity(file, &["--env=FOO=BAR"]);
+    assert_parity(file, &["--env", "FOO=BAR"]);
+}
+
+#[test]
+fn unknown_option_matches_legacy_error_kind() {
+    let file = r#"
+#!/usr/bin/env rash
+#
+# Usage: tool [--known]
+#
+"#;
+
+    let legacy = docopt::parse(file, &["--unknown"]).unwrap_err();
+    let compiled = script_cli::parse(file, &["--unknown"]).unwrap_err();
+    assert_eq!(legacy.kind(), ErrorKind::InvalidData);
+    assert_eq!(compiled.kind(), legacy.kind());
+}
+
+#[test]
+fn help_command_and_option_match_legacy_exit_kind() {
+    let command = r#"
+#!/usr/bin/env rash
+#
+# Usage: tool (run|help)
+#
+"#;
+    let option = r#"
+#!/usr/bin/env rash
+#
+# Usage: tool [-h]
+#
+# Options:
+#   -h --help  help
+#
+"#;
+
+    assert_parity(command, &["help"]);
+    assert_parity(option, &["-h"]);
+    assert_parity(option, &["--help"]);
+}
+
+#[test]
+fn no_usage_returns_empty_context() {
+    let file = r#"
+#!/usr/bin/env rash
+# No CLI declaration here.
+- debug:
+    msg: hi
+"#;
+
+    assert_eq!(script_cli::parse(file, &[]).unwrap(), Value::Object(Default::default()));
+    assert_parity(file, &[]);
+}
+
+#[test]
+fn identical_bindings_from_overlapping_patterns_are_not_ambiguous() {
+    let file = r#"
+#!/usr/bin/env rash
+#
+# Usage:
+#   cp <source> <dest>
+#   cp <source>... <dest>
+#
+"#;
+
+    assert_parity(file, &["one", "dest"]);
+    assert_parity(file, &["one", "two", "dest"]);
+}
+
+#[test]
+fn repeated_group_rejects_incomplete_tail() {
+    let file = r#"
+#!/usr/bin/env rash
+#
+# Usage: tool (<a> <b>)...
+#
+"#;
+
+    assert_parity(file, &["1", "2"]);
+    assert_parity(file, &["1", "2", "3", "4"]);
+    assert_parity(file, &["1", "2", "3"]);
+}
+
+#[test]
+fn alternatives_and_optional_options_can_mix_positions() {
+    let file = r#"
+#!/usr/bin/env rash
+#
+# Usage: tool [--verbose] (start|stop) [--force]
+#
+# Options:
+#   --verbose  verbose
+#   --force    force
+#
+"#;
+
+    for args in [
+        vec!["start"],
+        vec!["--verbose", "start"],
+        vec!["stop", "--force"],
+        vec!["--force", "--verbose", "start"],
+    ] {
+        assert_parity(file, &args);
+    }
+}

--- a/rash_core/tests/script_cli_parity.rs
+++ b/rash_core/tests/script_cli_parity.rs
@@ -195,7 +195,10 @@ fn no_usage_returns_empty_context() {
     msg: hi
 "#;
 
-    assert_eq!(script_cli::parse(file, &[]).unwrap(), Value::Object(Default::default()));
+    assert_eq!(
+        script_cli::parse(file, &[]).unwrap(),
+        Value::Object(Default::default())
+    );
     assert_parity(file, &[]);
 }
 

--- a/rash_core/tests/script_cli_repeatable_value_option.rs
+++ b/rash_core/tests/script_cli_repeatable_value_option.rs
@@ -1,0 +1,45 @@
+use rash_core::{docopt, script_cli};
+
+fn assert_parity(file: &str, args: &[&str]) {
+    let legacy = docopt::parse(file, args);
+    let compiled = script_cli::parse(file, args);
+    match (legacy, compiled) {
+        (Ok(legacy), Ok(compiled)) => assert_eq!(compiled, legacy, "args={args:?}"),
+        (Err(legacy), Err(compiled)) => {
+            assert_eq!(compiled.kind(), legacy.kind(), "args={args:?}")
+        }
+        (legacy, compiled) => {
+            panic!("parser mismatch for args={args:?}: legacy={legacy:?} compiled={compiled:?}")
+        }
+    }
+}
+
+#[test]
+fn repeatable_value_option_preserves_scalar_last_value_semantics() {
+    let file = r#"
+#!/usr/bin/env rash
+#
+# Usage: tool [--tag=<value>]...
+#
+"#;
+
+    assert_parity(file, &[]);
+    assert_parity(file, &["--tag=one"]);
+    assert_parity(file, &["--tag=one", "--tag=two"]);
+}
+
+#[test]
+fn documented_repeatable_value_option_preserves_scalar_last_value_semantics() {
+    let file = r#"
+#!/usr/bin/env rash
+#
+# Usage: tool [--tag]...
+#
+# Options:
+#   --tag=VALUE  tag value
+#
+"#;
+
+    assert_parity(file, &["--tag", "one"]);
+    assert_parity(file, &["--tag=one", "--tag=two"]);
+}

--- a/rash_core/tests/script_cli_shared_alias.rs
+++ b/rash_core/tests/script_cli_shared_alias.rs
@@ -1,0 +1,44 @@
+use rash_core::{docopt, error::ErrorKind, script_cli};
+
+fn assert_parity(file: &str, args: &[&str]) {
+    let legacy = docopt::parse(file, args);
+    let compiled = script_cli::parse(file, args);
+    match (legacy, compiled) {
+        (Ok(legacy), Ok(compiled)) => assert_eq!(compiled, legacy, "args={args:?}"),
+        (Err(legacy), Err(compiled)) => {
+            assert_eq!(compiled.kind(), legacy.kind(), "args={args:?}")
+        }
+        (legacy, compiled) => {
+            panic!("parser mismatch for args={args:?}: legacy={legacy:?} compiled={compiled:?}")
+        }
+    }
+}
+
+#[test]
+fn duplicate_short_alias_keeps_both_unambiguous_long_options() {
+    let file = r#"
+#!/usr/bin/env rash
+#
+# Usage: tool [options]
+#
+# Options:
+#   -u --sysupgrade  upgrade
+#   -u --upgrades    list upgrades
+#
+"#;
+
+    assert_parity(file, &["--sysupgrade"]);
+    assert_parity(file, &["--upgrades"]);
+
+    let error = script_cli::parse(file, &["-u"]).unwrap_err();
+    assert_eq!(error.kind(), ErrorKind::InvalidData);
+    assert!(error.to_string().contains("Ambiguous option alias: -u"));
+}
+
+#[test]
+fn real_pacman_fixture_parses_unambiguous_long_aliases() {
+    let file = include_str!("mocks/pacman.rh");
+    assert_parity(file, &["--sysupgrade"]);
+    assert_parity(file, &["--upgrades"]);
+    assert_parity(file, &["--sync", "--noconfirm", "rash"]);
+}

--- a/rash_core/tests/script_cli_usage_extraction.rs
+++ b/rash_core/tests/script_cli_usage_extraction.rs
@@ -1,0 +1,59 @@
+use rash_core::{docopt, script_cli};
+
+fn assert_parity(file: &str, args: &[&str]) {
+    let legacy = docopt::parse(file, args);
+    let compiled = script_cli::parse(file, args);
+    match (legacy, compiled) {
+        (Ok(legacy), Ok(compiled)) => assert_eq!(compiled, legacy, "args={args:?}"),
+        (Err(legacy), Err(compiled)) => {
+            assert_eq!(compiled.kind(), legacy.kind(), "args={args:?}")
+        }
+        (legacy, compiled) => {
+            panic!("parser mismatch for args={args:?}: legacy={legacy:?} compiled={compiled:?}")
+        }
+    }
+}
+
+#[test]
+fn standard_one_line_usage_remains_active() {
+    let file = r#"
+#!/usr/bin/env rash
+# Usage: tool <value>
+#
+"#;
+    assert_parity(file, &["x"]);
+}
+
+#[test]
+fn usage_without_comment_spacing_keeps_legacy_inactive_behavior() {
+    let file = r#"
+#!/usr/bin/env rash
+#Usage: tool <value>
+#
+"#;
+    assert_parity(file, &["x"]);
+}
+
+#[test]
+fn usage_without_colon_spacing_keeps_legacy_inactive_behavior() {
+    let file = r#"
+#!/usr/bin/env rash
+# Usage:tool <value>
+#
+"#;
+    assert_parity(file, &["x"]);
+}
+
+#[test]
+fn multiline_usage_preserves_legacy_indentation_rules() {
+    let file = r#"
+#!/usr/bin/env rash
+#
+# Usage:
+#   tool get <value>
+#   tool set <value>
+#
+"#;
+    assert_parity(file, &["get", "x"]);
+    assert_parity(file, &["set", "x"]);
+}


### PR DESCRIPTION
## Goal

Replace Rash's current usage-expansion based script CLI parser with a deterministic compiled matcher while preserving the existing user-facing CLI syntax and output contract.

This PR is intentionally large, but it is being built in explicit phases so correctness and performance can be evaluated independently.

## Engineering plan and progress

The detailed phase plan, invariants, exit criteria, rollback conditions, benchmark gates, and durable progress log live in [`rash_core/SCRIPT_CLI_PARSER_REFACTOR.md`](https://github.com/rash-sh/rash/blob/refactor/compiled-script-cli-parser/rash_core/SCRIPT_CLI_PARSER_REFACTOR.md).

Current phase state:

- [x] Phase 0 — contract capture and baseline
- [x] Phase 1 — explicit grammar model
- [x] Phase 2 — option registry and argv normalization
- [ ] Phase 3 — compiled matcher hardening
- [ ] Phase 4 — differential compatibility campaign
- [ ] Phase 5 — performance validation and optimization
- [ ] Phase 6 — production integration
- [ ] Phase 7 — supported-language documentation
- [ ] Phase 8 — legacy cleanup decision
- [ ] Phase 9 — final release gate

The plan document is the source of truth for detailed progress and will be updated when phase gates materially change.

## Design

The new parser:

- parses usage declarations into an AST (`sequence`, `alternative`, `optional`, `required`, `repeat`, commands, positional arguments, options, unordered option groups, and `[options]`);
- compiles the AST into an epsilon-NFA instead of generating concrete usage combinations;
- walks normalized argv directly against the compiled graph;
- represents repetition as graph cycles rather than argument-count-driven expansion;
- stores captures in a persistent path arena so long repeatable argument lists do not repeatedly clone accumulated values;
- represents unordered optional options structurally instead of generating permutations;
- scopes `[options]` to each usage pattern;
- rejects successful paths with different bindings as ambiguous while accepting equivalent paths that produce the same bindings.

## Migration strategy

The legacy `docopt` parser remains in-tree during this PR as a differential-test and benchmark oracle. Production will only switch to the new parser after compatibility and performance gates are satisfied.

## Compatibility policy

This is a parser replacement, not a CLI redesign. Existing valid Rash script interfaces should retain their current variable shapes and option behavior unless an existing behavior is demonstrably nondeterministic or incorrect. Intentional correctness changes will be called out explicitly in this PR and covered by regression tests.

## Scope intentionally deferred

The separate Rash-interpreter-vs-script argv boundary (`rash script.rh -- --script-option`) is not changed here. That is a user-facing CLI behavior change and should not be mixed into parser-engine replacement until this parser is proven.
